### PR TITLE
feat(arch): stdout-first npm run arch with default all graphs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# Overview
+
+mcp-app-room (`@mcp-app-room`) extends (`@modelcontextprotocol/ext-apps`), which enables MCP servers to display interactive UIs in conversational clients, to enable "views/rooms" (roomd) that host multiple app instances in a shared layout, with cross-instance interactions and room-level tools. While a bookmark on a web page is a single page, a room is a persistent container for multiple apps, like a virtual desktop or dashboard. This allows users to organize related apps together, share them with others, and create more complex interactions across apps in the same room. A room may not have a UI, which we also support as a headless mount of tools.
+
+`@modelcontextprotocol/ext-apps` Key abstractions:
+
+- **View** - UI running in an iframe, uses `App` class with `PostMessageTransport` to communicate with host
+- **Host** - Chat client embedding the iframe, uses `AppBridge` class to proxy MCP requests
+- **Server** - MCP server that registers tools/resources with UI metadata
+
+`@mcp-app-room` adds:
+- **Room** - Persistent container for multiple app instances, with layout and shared tools
+- **Instance** - An app mounted in a room, linked to a specific tool and UI
+- **Layout** - Defines how instances are arranged in the room (e.g. grid, tabs)
+- **Room-level tools** - Tools that operate at the room level, not tied to a specific instance, where we simplyfy MCP communcation via a roomctl CLI and roomd server.
+- **Cross-instance interactions** - Tools can reference other instances in the same room safely via the user, without the implementation details leaking between them.
+
+## IMPORTANT:
+
+- **MOST IMPORTANT:** Please do the right thing. It might hard, it might go against your goal, but please do the right thing. If you don't know what the right thing is, ask! I'm here to help, but I can't if you don't ask.
+- **IMPORTANT**: This library utilizes @modelcontextprotol libraries and is a feature built on top of it. We must stay in line with their system and tooling, we cannot deviate.
+- **IMPORTANT:** Refactor often! Don't be afraid to change code. In fact, that's what we want! Repositories bloat quickly, if you see an opportunity to refactor, do it now, because later will be 100x harder.
+- If you disagree with what the user asks, push back!
+- Run `npm run arch` to stream Mermaid diagrams (deps + types + callgraph) with no file writes. Use `--deps`, `--types`, or `--callgraph` to stream a single graph.
+- Get todays date and time if you haven't today, because AI changes fast and looking at old documentation from 2025, when it's February 2026 (time of writing) is not okay, ever.
+- If you leave stale documentation, you're fired. (obviously not, we just care about the right thing and hope you do to)
+- No one cares if the build is green, that's a smoke test, it doesn't mean your code is good.
+- You are not a task monkey, you are a principal engineer, you operate at principal engineer level, do you understand what that means?
+- You have freedom, with freedom comes responsibility, you're basically spiderman, but a better dev.
+- See something weird in code ALWAYS WRITE A TODO OR GOTCHA COMMENT.
+- When creating backlog issues using the gh cli, you can add a label string by domain/team who you believe should handle it. This will make it clear to the team.
+- Fix CI issues permanently please, dig into them, they might be a bigger deal than it looks.
+- Use the GH cli tool. Never leave a dangling branch. Never leave a PR open. Merge it, resolve conflicts, install dependencies, fix issues.
+
+
+### General Best Practices
+
+### Git
+- We're on a shared jumpbox.
+- Never lock main.
+- Do active work on a named branch (not detached).
+- Run git fetch origin + git status -sb before starting a ticket.
+- After merges, explicitly sync both the main worktree and any detached audit worktrees.
+
+### Commands
+- `npm run arch` # streams architecture Mermaid graphs to stdout (all by default; `--deps|--types|--callgraph` for one).
+- `npm run arch:gen`  # explicitly regenerates docs/generated/... artifacts when file-based outputs are required.
+- `npm run test:all` # runs all tests, including unit and integration. Use this before pushing to make sure everything is good.
+
+### Apps-SDK Entry Points
+
+- `@modelcontextprotocol/ext-apps` - Main SDK for Apps (`App` class, `PostMessageTransport`)
+- `@modelcontextprotocol/ext-apps/react` - React hooks (`useApp`, `useHostStyleVariables`, etc.)
+- `@modelcontextprotocol/ext-apps/app-bridge` - SDK for hosts (`AppBridge` class)
+- `@modelcontextprotocol/ext-apps/server` - Server helpers (`registerAppTool`, `registerAppResource`)
+
+### What makes a good repository?
+
+A good repository optimizes for change over time, not just current correctness.
+
+At principal level, I'd use this bar:
+
+1.  Clear boundaries
+    - Code is organized by domain/responsibility, not random technical layers.
+    - Interfaces are explicit; coupling is intentional.
+2.  Fast comprehension
+    - A new engineer can open 1-2 files and understand system purpose and flow.
+    - Naming is precise and boringly clear.
+3.  Reliable contracts
+    - Inputs/outputs are validated.
+    - Invariants fail fast with useful errors.
+4.  Evolvable structure
+    - No god files.
+    - Modules are small enough to reason about and replace.
+5.  Operational readiness
+    - Deterministic config loading.
+    - Structured logs, health checks, graceful shutdown, predictable behavior under failure.
+6.  Testing that protects refactors
+    - Tests target behavior/contracts, not implementation trivia.
+    - Critical paths and edge cases are covered.
+7.  Documentation that stays true
+    - Each domain explains Overview, End State, and Input/Output contract.
+    - Docs reflect actual system boundaries and are maintained with code changes.
+8.  Tooling discipline
+    - Reproducible build/test/lint workflows.
+    - Dependency graph and architecture checks catch drift early.
+9.  One command to test. make test / npm test / go test ./... is documented and reliable.
+10. One command to build/run. make build / make dev (or equivalents) exist and don’t require tribal knowledge.
+11. Automate quality checks. Formatting, linting, type-checking, and tests are scriptable and consistent
+12. Enforce checks in CI. The default branch is protected; CI is the referee, not “please remember.”
+13. Use a consistent directory layout. A predictable home for src/, tests/, docs/, scripts/, etc.
+
+If a repo makes safe change easy, fast, and obvious, it's good.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,16 @@ Full policy, target-state rules, and baseline process are documented in
 
 ## Architecture Diagrams
 
-Compiler-backed architecture artifacts (dependency graph, type diagram, call graph)
-are generated to `docs/generated/`.
+Stream Mermaid graphs to stdout (no files written):
+
+```bash
+npm run arch                     # deps + types + callgraph (default)
+npm run arch -- --deps           # deps only
+npm run arch -- --types          # types only
+npm run arch -- --callgraph      # callgraph only
+```
+
+File-based artifact regeneration still exists for checked-in docs:
 
 ```bash
 npm run arch:gen

--- a/docs/architecture-linting.md
+++ b/docs/architecture-linting.md
@@ -36,7 +36,8 @@ Rules 7-9 are intentional target-state constraints. They are stricter than curre
 npm run arch:lint          # CI-safe mode (fails only on violations not in known-baseline)
 npm run arch:lint:strict   # strict mode (all violations)
 npm run arch:baseline      # refresh known-violations baseline
-npm run arch:deps:mermaid  # regenerate docs/generated/deps.mmd
+npm run arch               # print all Mermaid graphs to stdout (deps + types + callgraph)
+npm run arch -- --deps     # print dependency graph only
 npm run arch:gen           # generate full architecture docs in docs/generated/
 npm run arch:check         # fail when generated architecture artifacts drift
 ```

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -14,8 +14,11 @@ Artifacts in this directory are generated from static analysis and should remain
 ## Regeneration
 
 ```bash
+npm run arch                     # stream all Mermaid graphs to stdout
+npm run arch -- --deps           # stream dependency graph only
+npm run arch -- --types          # stream type graph only
+npm run arch -- --callgraph      # stream call graph only
 npm run arch:gen
-npm run arch:deps:mermaid
 npm run arch:check
 ```
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "arch:lint": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json apps services",
     "arch:lint:strict": "depcruise --config .dependency-cruiser.cjs apps services",
     "arch:baseline": "depcruise-baseline --config .dependency-cruiser.cjs apps services",
+    "arch": "node tools/arch/arch.mjs",
     "arch:gen": "bash scripts/generate-arch.sh docs/generated",
     "arch:check": "bash scripts/check-arch.sh",
     "arch:render": "ARCH_RENDER=1 bash scripts/generate-arch.sh docs/generated",
-    "arch:deps:mermaid": "bash scripts/generate-arch.sh docs/generated --deps-only",
+    "arch:deps:mermaid": "npm run arch -- --deps",
     "test:e2e": "playwright test",
     "playwright": "node scripts/playwright-cdp-shell.mjs",
     "playwright:test": "playwright test"

--- a/tools/arch/README.md
+++ b/tools/arch/README.md
@@ -9,10 +9,30 @@ Architecture generation is driven by:
 Run from repo root:
 
 ```bash
-npm run arch:gen
+npm run arch
 ```
 
-This writes artifacts to `docs/generated/` by default.
+`npm run arch` prints Mermaid output to stdout and writes no files.
+
+Default output includes all graph families:
+
+- dependency graph
+- type graph
+- call graph
+
+Select exactly one graph family when needed:
+
+```bash
+npm run arch -- --deps
+npm run arch -- --types
+npm run arch -- --callgraph
+```
+
+Use file-based generation only when you explicitly need `docs/generated/` artifacts:
+
+```bash
+npm run arch:gen
+```
 
 Generated files:
 

--- a/tools/arch/arch.mjs
+++ b/tools/arch/arch.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function parseArgs(argv) {
+  let configPath = "tools/arch/arch.config.json";
+  const selected = {
+    deps: false,
+    types: false,
+    callgraph: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--config") {
+      configPath = argv[i + 1] ?? configPath;
+      i += 1;
+      continue;
+    }
+    if (arg === "--deps") {
+      selected.deps = true;
+      continue;
+    }
+    if (arg === "--types") {
+      selected.types = true;
+      continue;
+    }
+    if (arg === "--callgraph") {
+      selected.callgraph = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      process.stdout.write(
+        "Usage: npm run arch -- [--deps] [--types] [--callgraph] [--config <path>]\n",
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  const noneSelected = !selected.deps && !selected.types && !selected.callgraph;
+  if (noneSelected) {
+    return {
+      configPath,
+      deps: true,
+      types: true,
+      callgraph: true,
+    };
+  }
+
+  const selectedCount = Number(selected.deps) + Number(selected.types) + Number(selected.callgraph);
+  if (selectedCount > 1) {
+    throw new Error("Select only one graph flag: --deps, --types, or --callgraph");
+  }
+
+  return { configPath, ...selected };
+}
+
+function readConfig(repoRoot, configPath) {
+  const fullPath = path.resolve(repoRoot, configPath);
+  const raw = JSON.parse(readFileSync(fullPath, "utf8"));
+  return {
+    roots: Array.isArray(raw.roots) && raw.roots.length > 0 ? raw.roots : ["src"],
+    includeOnly: typeof raw.includeOnly === "string" ? raw.includeOnly : "^src",
+    exclude: Array.isArray(raw.exclude)
+      ? raw.exclude.filter((item) => typeof item === "string" && item.length > 0)
+      : [],
+    configPath: fullPath,
+  };
+}
+
+function runCommand(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `Command failed: ${command} ${args.join(" ")}`,
+        result.stderr?.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return (result.stdout ?? "").trim();
+}
+
+function buildDepsMermaid(repoRoot, config) {
+  const excludeRegex = config.exclude.length > 0 ? config.exclude.join("|") : "^$";
+  return runCommand(
+    "npx",
+    [
+      "depcruise",
+      "--no-config",
+      "--include-only",
+      config.includeOnly,
+      "--exclude",
+      excludeRegex,
+      "--output-type",
+      "mermaid",
+      ...config.roots,
+    ],
+    repoRoot,
+  );
+}
+
+function buildTypeAndCallMermaid(repoRoot, configPath, wantTypes, wantCallgraph) {
+  const args = [
+    "tools/arch/generate.mjs",
+    "--stdout",
+    "--config",
+    configPath,
+  ];
+  if (wantTypes && !wantCallgraph) {
+    args.push("--types-only");
+  } else if (!wantTypes && wantCallgraph) {
+    args.push("--callgraph-only");
+  } else if (wantTypes && wantCallgraph) {
+    args.push("--types", "--callgraph");
+  }
+  return runCommand("node", args, repoRoot);
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const args = parseArgs(process.argv.slice(2));
+  const config = readConfig(repoRoot, args.configPath);
+
+  const outputParts = [];
+  if (args.deps) {
+    outputParts.push(`%% graph:deps\n${buildDepsMermaid(repoRoot, config)}`);
+  }
+  if (args.types || args.callgraph) {
+    outputParts.push(
+      buildTypeAndCallMermaid(repoRoot, config.configPath, args.types, args.callgraph),
+    );
+  }
+
+  process.stdout.write(`${outputParts.filter(Boolean).join("\n")}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/tools/arch/generate.mjs
+++ b/tools/arch/generate.mjs
@@ -155,9 +155,61 @@ function shouldExcludeByName(name, filters) {
   return filters.some((regex) => regex.test(name));
 }
 
+function parseCliArgs(argv) {
+  const positional = [];
+  const flags = new Set();
+  let configPathArg;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--config") {
+      configPathArg = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      flags.add(arg);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const stdout = flags.has("--stdout");
+  const typesOnly = flags.has("--types-only");
+  const callgraphOnly = flags.has("--callgraph-only");
+  const typesSelected = flags.has("--types");
+  const callgraphSelected = flags.has("--callgraph");
+
+  let includeTypes = true;
+  let includeCallgraph = true;
+  if (typesOnly) {
+    includeTypes = true;
+    includeCallgraph = false;
+  } else if (callgraphOnly) {
+    includeTypes = false;
+    includeCallgraph = true;
+  } else if (typesSelected || callgraphSelected) {
+    includeTypes = typesSelected;
+    includeCallgraph = callgraphSelected;
+  }
+
+  return {
+    outputDirArg: positional[0] ?? "docs/generated",
+    configPathArg: configPathArg ?? positional[1] ?? "tools/arch/arch.config.json",
+    stdout,
+    includeTypes,
+    includeCallgraph,
+  };
+}
+
 async function main() {
-  const outputDirArg = process.argv[2] ?? "docs/generated";
-  const configPathArg = process.argv[3] ?? "tools/arch/arch.config.json";
+  const {
+    outputDirArg,
+    configPathArg,
+    stdout,
+    includeTypes,
+    includeCallgraph,
+  } = parseCliArgs(process.argv.slice(2));
 
   const repoRoot = process.cwd();
   const outputDir = path.resolve(repoRoot, outputDirArg);
@@ -608,10 +660,32 @@ async function main() {
     callgraphMermaidLines.push(`  ${edge.from.id} --> ${edge.to.id}`);
   }
 
+  const outputs = {
+    typesMmd: `${typeLines.join("\n")}\n`,
+    callgraphTxt: `${callgraphTxtLines.join("\n")}\n`,
+    callgraphMmd: `${callgraphMermaidLines.join("\n")}\n`,
+  };
+
+  if (stdout) {
+    if (includeTypes) {
+      process.stdout.write("%% graph:types\n");
+      process.stdout.write(outputs.typesMmd);
+    }
+    if (includeCallgraph) {
+      process.stdout.write("%% graph:callgraph\n");
+      process.stdout.write(outputs.callgraphMmd);
+    }
+    return;
+  }
+
   await fs.mkdir(outputDir, { recursive: true });
-  await fs.writeFile(path.join(outputDir, "types.mmd"), `${typeLines.join("\n")}\n`, "utf8");
-  await fs.writeFile(path.join(outputDir, "callgraph-app.txt"), `${callgraphTxtLines.join("\n")}\n`, "utf8");
-  await fs.writeFile(path.join(outputDir, "callgraph.mmd"), `${callgraphMermaidLines.join("\n")}\n`, "utf8");
+  if (includeTypes) {
+    await fs.writeFile(path.join(outputDir, "types.mmd"), outputs.typesMmd, "utf8");
+  }
+  if (includeCallgraph) {
+    await fs.writeFile(path.join(outputDir, "callgraph-app.txt"), outputs.callgraphTxt, "utf8");
+    await fs.writeFile(path.join(outputDir, "callgraph.mmd"), outputs.callgraphMmd, "utf8");
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- add a new single entrypoint `npm run arch` that prints Mermaid graph output to stdout and writes no files
- make `npm run arch` default to all graph families (`deps`, `types`, `callgraph`)
- support selecting a single graph with exactly one flag: `--deps`, `--types`, or `--callgraph`
- keep file-based generation (`arch:gen`, `arch:check`) available for checked-in artifacts
- update docs and `AGENTS.md` to reflect the new default workflow

## Changes
- added [tools/arch/arch.mjs](tools/arch/arch.mjs) as the stdout graph orchestrator
- updated [tools/arch/generate.mjs](tools/arch/generate.mjs) with `--stdout`, `--config`, and selective graph emission support
- added `arch` script and repointed `arch:deps:mermaid` to use the new CLI in [package.json](package.json)
- updated docs:
  - [README.md](README.md)
  - [tools/arch/README.md](tools/arch/README.md)
  - [docs/architecture-linting.md](docs/architecture-linting.md)
  - [docs/generated/README.md](docs/generated/README.md)
  - [AGENTS.md](AGENTS.md)

## Verification
- `npm run arch` (confirmed headers for deps/types/callgraph)
- `npm run arch -- --callgraph` (confirmed single graph output)
- `npm run repo:guard`
