### PR TITLE
docs(adr): move completed ticket 03 to CLOSED

### DIFF
--- a/docs/ADR/TICKETS/CLOSED/03-mcp-apps-optional-mount-and-discovery.md
+++ b/docs/ADR/TICKETS/CLOSED/03-mcp-apps-optional-mount-and-discovery.md
@@ -1,6 +1,9 @@
 # Title
 Make MCP Apps Optional in Mount Semantics and Discovery
 
+# Status
+Closed (merged via PR #2 on 2026-02-28)
+
 # Priority
 P0
 

--- a/docs/ADR/TICKETS/README.md
+++ b/docs/ADR/TICKETS/README.md
@@ -8,32 +8,27 @@ Execution order (recommended):
 
 1. `01-capability-session-matrix.md`
 2. `02-core-server-primitives-parity.md`
-3. `03-mcp-apps-optional-mount-and-discovery.md`
-4. `04-roomd-error-taxonomy-and-surface-contracts.md`
-5. `05-conformance-ci-tier2-gate.md`
-6. `06-transport-adapter-architecture-and-stdio-design.md`
-7. `07-stdio-transport-implementation.md`
-8. `08-client-capabilities-roots-sampling-elicitation.md`
-9. `09-http-auth-strategy-and-security-hardening.md`
-10. `10-tier1-conformance-support-matrices-and-deprecation.md`
+3. `04-roomd-error-taxonomy-and-surface-contracts.md`
+4. `05-conformance-ci-tier2-gate.md`
+5. `06-transport-adapter-architecture-and-stdio-design.md`
+6. `07-stdio-transport-implementation.md`
+7. `08-client-capabilities-roots-sampling-elicitation.md`
+8. `09-http-auth-strategy-and-security-hardening.md`
+9. `10-tier1-conformance-support-matrices-and-deprecation.md`
 
 Milestone targets:
 
 - End of Q2 2026: Tier 2 conformance threshold and Apps-safe non-UI-first behavior.
 - End of Q3 2026: Tier 1 conformance threshold, stdio support, auth hardening, published support matrices.
 
-## First PR Decision
+## Closed
 
-Start with `03-mcp-apps-optional-mount-and-discovery.md` as a focused,
-user-visible safety slice, then execute the core protocol hardening sequence:
+- `03-mcp-apps-optional-mount-and-discovery.md`
+  - moved to `CLOSED/`
+  - merged via PR #2 on 2026-02-28
 
-1. `03-mcp-apps-optional-mount-and-discovery.md`
-2. `01-capability-session-matrix.md`
-3. `02-core-server-primitives-parity.md`
-4. `04-roomd-error-taxonomy-and-surface-contracts.md`
+## Next Up
 
-Rationale:
-- Current host and CLI behavior is blocked by UI-first mount assumptions, so a
-  non-UI-safe mount path is the highest product-risk reducer.
-- Ticket `01` remains foundational for capability contracts and is executed
-  immediately after `03` to restore strict protocol-first guardrails.
+1. `01-capability-session-matrix.md`
+2. `02-core-server-primitives-parity.md`
+3. `04-roomd-error-taxonomy-and-surface-contracts.md`


### PR DESCRIPTION
## Summary
- move completed Ticket 03 into `docs/ADR/TICKETS/CLOSED/`
- mark Ticket 03 closed with merge reference (PR #2, 2026-02-28)
- update ticket index to reflect current open execution order and explicit next-up sequence

## Why
Ticket 03 has already been implemented and merged. Keeping it in the open list creates roadmap drift.

## Next Tickets
1. `01-capability-session-matrix.md`
2. `02-core-server-primitives-parity.md`
3. `04-roomd-error-taxonomy-and-surface-contracts.md`
