### PR TITLE
roomd: add structured logging, preserve selected instance on tool calls, and bootstrap local dev rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ Global flags:
 ## Developer Checks
 
 ```bash
-npm run verify:fast   # fast local checks
 npm run verify        # default pre-push command
-npm run verify:full   # includes e2e + conformance tier1
 ```
 
 ## Real MCP Fixture
@@ -155,9 +153,6 @@ Stream Mermaid graphs to stdout (no files written):
 
 ```bash
 npm run arch                     # deps + types + callgraph (default)
-npm run arch -- --deps           # deps only
-npm run arch -- --types          # types only
-npm run arch -- --callgraph      # callgraph only
 ```
 
 ## Repository Guardrails

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -4,7 +4,7 @@
 version: 1
 
 roomd:
-  baseUrl: "http://localhost:8090"
+  baseUrl: "http://localhost:8092"
 
 host:
   mode: "room"
@@ -13,12 +13,12 @@ host:
   # roomConfigId: "banking-room"
   # roomConfigNamespace: "default"
   ports:
-    host: 8080
-    sandbox: 8081
+    host: 8980
+    sandbox: 8981
   browser:
     remoteDebuggingPort: 9222
   servers:
-    - "http://localhost:3001/mcp"
+    - "http://localhost:3101/mcp"
 
 security:
   # strict | local-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2970,12 +2970,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3382,9 +3382,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3483,9 +3483,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/scripts/global-config.mjs
+++ b/scripts/global-config.mjs
@@ -53,6 +53,16 @@ function asStringArray(value, path, fallback) {
   throw new Error(`${path} must include at least one string`);
 }
 
+function splitCommaList(value) {
+  if (typeof value !== "string") {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
 function toAbsolutePath(cwd, value) {
   if (typeof value !== "string" || value.trim().length === 0) {
     return undefined;
@@ -141,4 +151,17 @@ export function loadGlobalConfig(configPath) {
       profile: securityProfile,
     },
   };
+}
+
+export function resolveBootstrapRooms(config, existingValue = process.env.ROOMD_BOOTSTRAP_ROOMS) {
+  const roomIds = new Set(splitCommaList(existingValue));
+
+  if (config?.host?.mode === "room" && typeof config.host.roomId === "string") {
+    const roomId = config.host.roomId.trim();
+    if (roomId.length > 0) {
+      roomIds.add(roomId);
+    }
+  }
+
+  return [...roomIds];
 }

--- a/scripts/global-config.test.mjs
+++ b/scripts/global-config.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveBootstrapRooms } from "./global-config.mjs";
+
+test("resolveBootstrapRooms adds the configured host room in room mode", () => {
+  const roomIds = resolveBootstrapRooms(
+    {
+      host: {
+        mode: "room",
+        roomId: "demo",
+      },
+    },
+    undefined,
+  );
+
+  assert.deepEqual(roomIds, ["demo"]);
+});
+
+test("resolveBootstrapRooms preserves explicit env rooms and de-duplicates the host room", () => {
+  const roomIds = resolveBootstrapRooms(
+    {
+      host: {
+        mode: "room",
+        roomId: "demo",
+      },
+    },
+    "alpha, demo, beta",
+  );
+
+  assert.deepEqual(roomIds, ["alpha", "demo", "beta"]);
+});
+
+test("resolveBootstrapRooms skips host bootstrap when not in room mode", () => {
+  const roomIds = resolveBootstrapRooms(
+    {
+      host: {
+        mode: "single-app",
+        roomId: "demo",
+      },
+    },
+    "alpha",
+  );
+
+  assert.deepEqual(roomIds, ["alpha"]);
+});

--- a/scripts/run-roomd.mjs
+++ b/scripts/run-roomd.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   loadGlobalConfig,
+  resolveBootstrapRooms,
   resolveGlobalConfigPath,
 } from "./global-config.mjs";
 
@@ -124,16 +125,21 @@ if (profile !== "strict" && profile !== "local-dev") {
   process.exit(1);
 }
 
+const bootstrapRooms = resolveBootstrapRooms(config);
+
 const env = {
   ...process.env,
   MCP_APP_ROOM_CONFIG: configPath,
   ROOMD_PORT: String(config.roomd.port),
+  // GOTCHA: browsers can reconnect to the previous room EventSource before the
+  // host process has time to recreate the default room during `npm run dev`.
+  ROOMD_BOOTSTRAP_ROOMS: bootstrapRooms.join(","),
   DANGEROUSLY_ALLOW_STDIO: profile === "local-dev" ? "true" : "false",
   DANGEROUSLY_ALLOW_REMOTE_HTTP: profile === "local-dev" ? "true" : "false",
 };
 
 console.log(
-  `[roomd] config=${configPath} baseUrl=${config.roomd.baseUrl} profile=${profile}`,
+  `[roomd] config=${configPath} baseUrl=${config.roomd.baseUrl} profile=${profile} bootstrapRooms=${bootstrapRooms.join(",") || "(none)"}`,
 );
 
 const child = spawn(

--- a/services/roomd/src/logging.ts
+++ b/services/roomd/src/logging.ts
@@ -1,0 +1,127 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RoomdLogLevel = "debug" | "info" | "warn" | "error";
+
+type LogFields = Record<string, unknown>;
+
+const LOG_LEVEL_PRIORITY: Record<RoomdLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const contextStore = new AsyncLocalStorage<LogFields>();
+
+function parseLogLevel(value: string | undefined): RoomdLogLevel {
+  switch (value?.trim().toLowerCase()) {
+    case "debug":
+    case "info":
+    case "warn":
+    case "error":
+      return value.trim().toLowerCase() as RoomdLogLevel;
+    default:
+      return "debug";
+  }
+}
+
+const configuredLevel = parseLogLevel(process.env.ROOMD_LOG_LEVEL);
+
+export interface RoomdLogger {
+  child(bindings: LogFields): RoomdLogger;
+  debug(message: string, fields?: LogFields): void;
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+}
+
+class JsonRoomdLogger implements RoomdLogger {
+  constructor(private readonly bindings: LogFields = {}) {}
+
+  child(bindings: LogFields): RoomdLogger {
+    return new JsonRoomdLogger({ ...this.bindings, ...omitUndefined(bindings) });
+  }
+
+  debug(message: string, fields?: LogFields): void {
+    this.emit("debug", message, fields);
+  }
+
+  info(message: string, fields?: LogFields): void {
+    this.emit("info", message, fields);
+  }
+
+  warn(message: string, fields?: LogFields): void {
+    this.emit("warn", message, fields);
+  }
+
+  error(message: string, fields?: LogFields): void {
+    this.emit("error", message, fields);
+  }
+
+  private emit(level: RoomdLogLevel, message: string, fields?: LogFields): void {
+    if (LOG_LEVEL_PRIORITY[level] < LOG_LEVEL_PRIORITY[configuredLevel]) {
+      return;
+    }
+
+    const payload = {
+      ts: new Date().toISOString(),
+      level,
+      msg: message,
+      ...this.bindings,
+      ...(contextStore.getStore() ?? {}),
+      ...(fields ? omitUndefined(fields) : {}),
+    };
+    const line = JSON.stringify(payload);
+
+    if (level === "warn") {
+      console.warn(line);
+      return;
+    }
+    if (level === "error") {
+      console.error(line);
+      return;
+    }
+    console.log(line);
+  }
+}
+
+const rootLogger = new JsonRoomdLogger({ service: "roomd" });
+
+export function getRoomdLogger(bindings: LogFields = {}): RoomdLogger {
+  return rootLogger.child(bindings);
+}
+
+export function getLogContext(): LogFields {
+  return contextStore.getStore() ?? {};
+}
+
+export function runWithLogContext<T>(
+  context: LogFields,
+  callback: () => T,
+): T {
+  const current = contextStore.getStore() ?? {};
+  return contextStore.run({ ...current, ...omitUndefined(context) }, callback);
+}
+
+export function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(error.stack ? { stack: error.stack } : {}),
+    };
+  }
+  return {
+    message: String(error),
+  };
+}
+
+function omitUndefined(fields: LogFields): LogFields {
+  const result: LogFields = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/services/roomd/src/mcp-session.ts
+++ b/services/roomd/src/mcp-session.ts
@@ -12,6 +12,7 @@ import {
   parseUiResourceMeta,
   readUiResourceMetaCandidate,
 } from "./mcp-ui-resource";
+import { getRoomdLogger, serializeError } from "./logging";
 
 interface SessionClient {
   close(): Promise<void>;
@@ -42,6 +43,7 @@ interface RealMcpSessionOptions {
 
 export class RealMcpSession implements McpSession {
   private resourceCache: Map<string, unknown> = new Map();
+  private readonly logger = getRoomdLogger({ component: "mcp_session" });
 
   constructor(
     private readonly client: SessionClient,
@@ -61,42 +63,82 @@ export class RealMcpSession implements McpSession {
   }
 
   async close(): Promise<void> {
+    this.logger.info("close.enter");
     // GOTCHA: stdio subprocess shutdown fallback (SIGTERM/SIGKILL) is delegated
     // to SDK transport close implementation; this must always run on release.
     await this.client.close();
+    this.logger.info("close.exit");
   }
 
   async notifyRootsListChanged(): Promise<void> {
+    this.logger.info("notifyRootsListChanged.enter");
     await this.client.notification({
       method: "notifications/roots/list_changed",
     });
+    this.logger.info("notifyRootsListChanged.exit");
   }
 
   async callTool(toolName: string, input: Record<string, unknown>): Promise<unknown> {
-    return this.client.callTool({ name: toolName, arguments: input });
+    this.logger.info("callTool.enter", {
+      toolName,
+      argumentKeys: Object.keys(input),
+    });
+    try {
+      const result = await this.client.callTool({ name: toolName, arguments: input });
+      this.logger.info("callTool.exit", { toolName });
+      return result;
+    } catch (error) {
+      this.logger.debug("callTool.error", {
+        toolName,
+        error: serializeError(error),
+      });
+      throw error;
+    }
   }
 
   async getPrompt(params: PromptGetParams): Promise<unknown> {
-    return this.client.getPrompt(params);
+    this.logger.info("getPrompt.enter", {
+      name: params.name,
+      hasArguments: !!params.arguments && Object.keys(params.arguments).length > 0,
+    });
+    const result = await this.client.getPrompt(params);
+    this.logger.info("getPrompt.exit", { name: params.name });
+    return result;
   }
 
   async complete(params: CompletionCompleteParams): Promise<unknown> {
-    return this.client.complete(params);
+    this.logger.info("complete.enter", {
+      hasContext: !!params.context,
+      argumentName: params.argument.name,
+    });
+    const result = await this.client.complete(params);
+    this.logger.info("complete.exit", { argumentName: params.argument.name });
+    return result;
   }
 
   async subscribeResource(params: ResourceSubscriptionParams): Promise<unknown> {
-    return this.client.subscribeResource(params);
+    this.logger.info("subscribeResource.enter", { uri: params.uri });
+    const result = await this.client.subscribeResource(params);
+    this.logger.info("subscribeResource.exit", { uri: params.uri });
+    return result;
   }
 
   async unsubscribeResource(params: ResourceSubscriptionParams): Promise<unknown> {
-    return this.client.unsubscribeResource(params);
+    this.logger.info("unsubscribeResource.enter", { uri: params.uri });
+    const result = await this.client.unsubscribeResource(params);
+    this.logger.info("unsubscribeResource.exit", { uri: params.uri });
+    return result;
   }
 
   async listTools(params?: { cursor?: string }): Promise<unknown> {
-    return this.client.listTools(params);
+    this.logger.info("listTools.enter", { cursor: params?.cursor });
+    const result = await this.client.listTools(params);
+    this.logger.info("listTools.exit", { cursor: params?.cursor });
+    return result;
   }
 
   async readUiResource(uri: string): Promise<ToolUiResource> {
+    this.logger.info("readUiResource.enter", { uri });
     const rawResource = await this.client.readResource({ uri });
     const resource = asRecord(rawResource);
 
@@ -126,28 +168,47 @@ export class RealMcpSession implements McpSession {
     const listingMeta = await this.readResourceListingMeta(uri);
     const uiMeta = contentMeta ?? listingMeta;
 
-    return {
+    const uiResource = {
       uiResourceUri: uri,
       html,
       csp: uiMeta?.csp,
       permissions: uiMeta?.permissions,
     };
+    this.logger.info("readUiResource.exit", {
+      uri,
+      htmlBytes: uiResource.html.length,
+      hasCsp: !!uiResource.csp,
+      hasPermissions: !!uiResource.permissions,
+    });
+    return uiResource;
   }
 
   async listResources(params?: { cursor?: string }): Promise<unknown> {
-    return this.client.listResources(params);
+    this.logger.info("listResources.enter", { cursor: params?.cursor });
+    const result = await this.client.listResources(params);
+    this.logger.info("listResources.exit", { cursor: params?.cursor });
+    return result;
   }
 
   async readResource(params: { uri: string }): Promise<unknown> {
-    return this.client.readResource(params);
+    this.logger.info("readResource.enter", { uri: params.uri });
+    const result = await this.client.readResource(params);
+    this.logger.info("readResource.exit", { uri: params.uri });
+    return result;
   }
 
   async listResourceTemplates(params?: { cursor?: string }): Promise<unknown> {
-    return this.client.listResourceTemplates(params);
+    this.logger.info("listResourceTemplates.enter", { cursor: params?.cursor });
+    const result = await this.client.listResourceTemplates(params);
+    this.logger.info("listResourceTemplates.exit", { cursor: params?.cursor });
+    return result;
   }
 
   async listPrompts(params?: { cursor?: string }): Promise<unknown> {
-    return this.client.listPrompts(params);
+    this.logger.info("listPrompts.enter", { cursor: params?.cursor });
+    const result = await this.client.listPrompts(params);
+    this.logger.info("listPrompts.exit", { cursor: params?.cursor });
+    return result;
   }
 
   getServerCapabilities(): unknown {
@@ -157,6 +218,10 @@ export class RealMcpSession implements McpSession {
   private async readResourceListingMeta(
     uri: string,
   ): Promise<UiResourceMeta | undefined> {
+    this.logger.debug("readResourceListingMeta.enter", {
+      uri,
+      cacheSize: this.resourceCache.size,
+    });
     if (!this.resourceCache.has(uri)) {
       const rawListing = await this.client.listResources();
       const listing = asRecord(rawListing);
@@ -171,11 +236,17 @@ export class RealMcpSession implements McpSession {
     }
 
     const listingResource = this.resourceCache.get(uri) as ResourceMetaContainer | undefined;
-    return parseUiResourceMeta(
+    const parsedMeta = parseUiResourceMeta(
       readUiResourceMetaCandidate(listingResource),
       "listing-level",
       this.options.safeParseUiMeta,
     );
+    this.logger.debug("readResourceListingMeta.exit", {
+      uri,
+      found: !!parsedMeta,
+      cacheSize: this.resourceCache.size,
+    });
+    return parsedMeta;
   }
 }
 

--- a/services/roomd/src/mcp-ui-resource.ts
+++ b/services/roomd/src/mcp-ui-resource.ts
@@ -1,3 +1,5 @@
+import { getRoomdLogger } from "./logging";
+
 export interface ResourceMetaContainer {
   _meta?: { ui?: unknown };
   meta?: { ui?: unknown };
@@ -13,6 +15,8 @@ interface UiMetaSafeParseResult {
   data?: UiResourceMeta;
   errorMessage?: string;
 }
+
+const logger = getRoomdLogger({ component: "mcp_ui_resource" });
 
 /**
  * Read `ui` metadata from MCP resource metadata containers.
@@ -42,10 +46,10 @@ export function parseUiResourceMeta(
 
   const parsed = safeParse(rawMeta);
   if (!parsed.success) {
-    console.warn(
-      `[roomd] Ignoring invalid ${level} UI metadata:`,
-      parsed.errorMessage ?? "invalid",
-    );
+    logger.warn("parseUiResourceMeta.invalid", {
+      level,
+      errorMessage: parsed.errorMessage ?? "invalid",
+    });
     return undefined;
   }
 

--- a/services/roomd/src/mcp.ts
+++ b/services/roomd/src/mcp.ts
@@ -36,9 +36,11 @@ import { registerClientCapabilityHandlers } from "./mcp-client-capabilities";
 import type { UiResourceMeta } from "./mcp-ui-resource";
 import { buildNegotiatedSession, readProtocolVersion } from "./mcp-session-metadata";
 import { RealMcpSession } from "./mcp-session";
+import { getRoomdLogger, serializeError } from "./logging";
 
 const IMPLEMENTATION = { name: "roomd", version: "0.1.0" };
 const UI_EXTENSION_KEY = "io.modelcontextprotocol/ui";
+const logger = getRoomdLogger({ component: "mcp_session_factory" });
 
 interface ConnectedClient {
   client: Client;
@@ -80,6 +82,11 @@ class HttpTransportAdapter implements TransportAdapter {
     serverKey: string,
     server: ServerDescriptor,
   ): Promise<ConnectedClient> {
+    const httpLogger = logger.child({
+      adapter: "http",
+      roomId,
+      server: serverKey,
+    });
     if (server.kind !== "http") {
       throw new Error("HTTP adapter only supports HTTP descriptors");
     }
@@ -112,13 +119,17 @@ class HttpTransportAdapter implements TransportAdapter {
         requestInit ? { requestInit } : undefined,
       );
       await streamableClient.connect(transport);
-      return {
+      const connected: ConnectedClient = {
         client: streamableClient,
         transport: "streamable-http",
         protocolVersion: readProtocolVersion(transport),
         clientCapabilities: advertisedCapabilities,
       };
+      return connected;
     } catch (error) {
+      httpLogger.debug("connect.streamable_http_failed", {
+        error: serializeError(error),
+      });
       streamableErrors.push(error);
     }
 
@@ -134,18 +145,23 @@ class HttpTransportAdapter implements TransportAdapter {
         requestInit ? { requestInit } : undefined,
       );
       await sseClient.connect(transport);
-      return {
+      const connected: ConnectedClient = {
         client: sseClient,
         transport: "legacy-sse",
         protocolVersion: readProtocolVersion(transport),
         clientCapabilities: advertisedCapabilities,
       };
+      return connected;
     } catch (error) {
+      httpLogger.debug("connect.sse_failed", {
+        error: serializeError(error),
+      });
       streamableErrors.push(error);
     }
 
     if (streamableErrors.some((error) => isUnauthorizedTransportError(error))) {
       if (strategy.type === "none") {
+        httpLogger.warn("connect.auth_required", { server: server.url });
         throw new RoomdAuthError(
           401,
           "AUTH_REQUIRED",
@@ -157,6 +173,10 @@ class HttpTransportAdapter implements TransportAdapter {
         );
       }
 
+      httpLogger.warn("connect.auth_failed", {
+        server: server.url,
+        strategy: strategy.type,
+      });
       throw new RoomdAuthError(
         401,
         "AUTH_FAILED",
@@ -177,7 +197,6 @@ class HttpTransportAdapter implements TransportAdapter {
       `Unable to establish HTTP/SSE MCP transport for ${server.url}: ${causes}`,
     );
   }
-
 }
 
 class StdioTransportAdapter implements TransportAdapter {
@@ -197,6 +216,11 @@ class StdioTransportAdapter implements TransportAdapter {
     serverKey: string,
     server: ServerDescriptor,
   ): Promise<ConnectedClient> {
+    const stdioLogger = logger.child({
+      adapter: "stdio",
+      roomId,
+      server: serverKey,
+    });
     if (server.kind !== "stdio") {
       throw new Error("Stdio adapter only supports stdio descriptors");
     }
@@ -225,12 +249,18 @@ class StdioTransportAdapter implements TransportAdapter {
 
     await client.connect(transport);
 
-    return {
+    const connected: ConnectedClient = {
       client,
       transport: "stdio",
       protocolVersion: readProtocolVersion(transport),
       clientCapabilities: advertisedCapabilities,
     };
+    stdioLogger.info("connect.exit", {
+      transport: connected.transport,
+      protocolVersion: connected.protocolVersion,
+      command: server.command,
+    });
+    return connected;
   }
 
   private assertCommandAllowed(command: string): void {
@@ -274,6 +304,12 @@ export class RealMcpSessionFactory implements McpSessionFactory {
   async getSession(roomId: string, serverUrl: string): Promise<McpSession> {
     const normalizedServer = normalizeServerTarget(serverUrl);
     const key = `${roomId}::${normalizedServer}`;
+    const sessionLogger = logger.child({
+      roomId,
+      server: normalizedServer,
+      cacheKey: key,
+    });
+    sessionLogger.info("getSession.enter");
 
     if (!this.sessions.has(key)) {
       const sessionPromise = (async () => {
@@ -310,10 +346,14 @@ export class RealMcpSessionFactory implements McpSessionFactory {
       );
     }
 
-    return this.sessions.get(key)!;
+    const session = await this.sessions.get(key)!;
+    sessionLogger.info("getSession.exit");
+    return session;
   }
 
   async releaseSession(roomId: string, serverUrl: string): Promise<void> {
+    const releaseLogger = logger.child({ roomId, serverUrl });
+    releaseLogger.info("releaseSession.enter");
     let normalizedServer: string;
     try {
       normalizedServer = normalizeServerTarget(serverUrl);
@@ -331,6 +371,7 @@ export class RealMcpSessionFactory implements McpSessionFactory {
     try {
       const session = await pending;
       await session.close();
+      releaseLogger.info("releaseSession.exit", { key });
     } catch {
       // Ignore close/retrieval failures during release path.
     }

--- a/services/roomd/src/room-config/service.ts
+++ b/services/roomd/src/room-config/service.ts
@@ -6,6 +6,7 @@ import type { RoomConfigRepository } from "./repository";
 import { assertValidRoomConfigSpec, orderRoomConfigInstances } from "./spec";
 import { NoopRoomConfigTelemetry } from "./telemetry";
 import type { RoomConfigTelemetry } from "./telemetry";
+import { getRoomdLogger, serializeError } from "../logging";
 import type {
   RoomConfigLoadPlan,
   RoomConfigPlanOperation,
@@ -27,6 +28,7 @@ interface ResolvedLoadPlan {
 
 export class RoomConfigService {
   private readonly telemetry: RoomConfigTelemetry;
+  private readonly logger = getRoomdLogger({ component: "room_config_service" });
 
   constructor(
     private readonly repository: RoomConfigRepository,
@@ -37,11 +39,13 @@ export class RoomConfigService {
   }
 
   async list(namespace: string): Promise<RoomConfigRecord[]> {
-    return this.repository.list(namespace);
+    const configs = await this.repository.list(namespace);
+    return configs;
   }
 
   async get(namespace: string, configId: string): Promise<RoomConfigRecord | null> {
-    return this.repository.get(namespace, configId);
+    const config = await this.repository.get(namespace, configId);
+    return config;
   }
 
   async upsert(input: RoomConfigUpsertInput): Promise<RoomConfigRecord> {
@@ -58,6 +62,11 @@ export class RoomConfigService {
     description?: string;
     tags?: string[];
   }): Promise<RoomConfigRecord> {
+    this.logger.info("saveFromRoomState.enter", {
+      namespace: input.namespace,
+      roomId: input.roomId,
+      configId: input.configId,
+    });
     const state = this.store.getState(input.roomId);
     const upsertInput = buildRoomConfigUpsertFromRoomState(
       {
@@ -71,10 +80,23 @@ export class RoomConfigService {
       },
       state,
     );
-    return this.persistUpsert("save", upsertInput, input.roomId);
+    const record = await this.persistUpsert("save", upsertInput, input.roomId);
+    this.logger.info("saveFromRoomState.exit", {
+      namespace: input.namespace,
+      roomId: input.roomId,
+      configId: input.configId,
+      revision: record.revision,
+    });
+    return record;
   }
 
   async planLoad(input: RoomConfigPlanInput): Promise<ResolvedLoadPlan> {
+    this.logger.info("planLoad.enter", {
+      namespace: input.namespace,
+      configId: input.configId,
+      roomId: input.roomId,
+      mode: input.mode,
+    });
     const config = await this.repository.get(input.namespace, input.configId);
     if (!config) {
       throw new HttpError(
@@ -126,7 +148,7 @@ export class RoomConfigService {
       ? config.spec.selectedInstanceId
       : instancesInApplyOrder[instancesInApplyOrder.length - 1]?.instanceId ?? null;
 
-    return {
+    const resolvedPlan = {
       config,
       plan: {
         operations,
@@ -138,9 +160,23 @@ export class RoomConfigService {
         },
       },
     };
+    this.logger.info("planLoad.exit", {
+      namespace: input.namespace,
+      configId: input.configId,
+      roomId: input.roomId,
+      operations: resolvedPlan.plan.operations.length,
+    });
+    return resolvedPlan;
   }
 
   async loadIntoRoom(input: RoomConfigLoadInput): Promise<RoomConfigLoadResult> {
+    this.logger.info("loadIntoRoom.enter", {
+      namespace: input.namespace,
+      configId: input.configId,
+      roomId: input.roomId,
+      mode: input.mode,
+      dryRun: input.dryRun,
+    });
     try {
       const resolved = await this.planLoad({
         namespace: input.namespace,
@@ -254,6 +290,12 @@ export class RoomConfigService {
         state: finalState,
       };
     } catch (error) {
+      this.logger.debug("loadIntoRoom.error", {
+        namespace: input.namespace,
+        configId: input.configId,
+        roomId: input.roomId,
+        error: serializeError(error),
+      });
       this.recordFailure("load", {
         namespace: input.namespace,
         configId: input.configId,
@@ -404,5 +446,4 @@ export class RoomConfigService {
     }
     return {};
   }
-
 }

--- a/services/roomd/src/room-config/telemetry.ts
+++ b/services/roomd/src/room-config/telemetry.ts
@@ -1,3 +1,5 @@
+import { getRoomdLogger } from "../logging";
+
 export interface RoomConfigMetricLabels {
   action: "upsert" | "load" | "save";
   status: "ok" | "error";
@@ -26,17 +28,19 @@ export interface RoomConfigTelemetry {
   record(event: RoomConfigAuditEvent): void;
 }
 
+const logger = getRoomdLogger({ component: "room_config_telemetry" });
+
 export class ConsoleRoomConfigTelemetry implements RoomConfigTelemetry {
   increment(
     metric: "room_config_requests_total",
     labels: RoomConfigMetricLabels,
   ): void {
     // GOTCHA: Metrics currently log to stdout until a real collector is wired.
-    console.info(JSON.stringify({ metric, labels }));
+    logger.info("metric.increment", { metric, labels });
   }
 
   record(event: RoomConfigAuditEvent): void {
-    console.info(JSON.stringify({ event: "room_config_audit", ...event }));
+    logger.info("audit.record", { event: "room_config_audit", ...event });
   }
 }
 

--- a/services/roomd/src/server-instance-routes.ts
+++ b/services/roomd/src/server-instance-routes.ts
@@ -13,6 +13,7 @@ import type {
   PromptGetParams,
   ResourceSubscriptionParams,
 } from "./types";
+import { getRoomdLogger } from "./logging";
 
 interface ParsedSchema<TParsed> {
   parse(input: unknown): TParsed;
@@ -25,11 +26,14 @@ interface InstanceRouteSchemas {
   unsubscribeRequestParamsSchema: ParsedSchema<ResourceSubscriptionParams>;
 }
 
+const logger = getRoomdLogger({ component: "instance_routes" });
+
 export function registerInstanceRoutes(
   app: express.Express,
   store: RoomStore,
   schemas: InstanceRouteSchemas,
 ): void {
+  logger.info("registerInstanceRoutes.enter");
   app.get("/rooms/:roomId/instances/:instanceId/ui", async (req, res, next) => {
     try {
       const resource = await store.getInstanceUiResource(
@@ -351,4 +355,5 @@ export function registerInstanceRoutes(
       }
     },
   );
+  logger.info("registerInstanceRoutes.exit");
 }

--- a/services/roomd/src/server-room-config-routes.ts
+++ b/services/roomd/src/server-room-config-routes.ts
@@ -7,11 +7,15 @@ import {
   roomConfigUpsertSchema,
 } from "./schema";
 import { RoomConfigService } from "./room-config/service";
+import { getRoomdLogger } from "./logging";
+
+const logger = getRoomdLogger({ component: "room_config_routes" });
 
 export function registerRoomConfigRoutes(
   app: express.Express,
   roomConfigService: RoomConfigService,
 ): void {
+  logger.info("registerRoomConfigRoutes.enter");
   app.get("/room-configs", async (req, res, next) => {
     try {
       const namespace = parseNamespaceQuery(req.query.namespace);
@@ -114,11 +118,16 @@ export function registerRoomConfigRoutes(
       next(error);
     }
   });
+  logger.info("registerRoomConfigRoutes.exit");
 }
 
 function parseNamespaceQuery(value: unknown): string {
+  logger.debug("parseNamespaceQuery.enter", { type: typeof value });
   if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim();
+    const parsed = value.trim();
+    logger.debug("parseNamespaceQuery.exit", { namespace: parsed });
+    return parsed;
   }
+  logger.debug("parseNamespaceQuery.exit", { namespace: "default" });
   return "default";
 }

--- a/services/roomd/src/server.ts
+++ b/services/roomd/src/server.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomUUID } from "node:crypto";
 import cors from "cors";
 import express from "express";
 import {
@@ -27,6 +28,9 @@ import {
 } from "./dev-security-overrides";
 import { RoomConfigService } from "./room-config/service";
 import { createSqliteRoomConfigRepository } from "./room-config/sqlite-repository";
+import { getRoomdLogger, runWithLogContext, serializeError } from "./logging";
+
+const logger = getRoomdLogger({ component: "server" });
 
 const port = Number.parseInt(process.env.ROOMD_PORT ?? "8090", 10);
 const eventWindowSize = Number.parseInt(
@@ -100,6 +104,41 @@ for (const roomId of parseCommaList(process.env.ROOMD_BOOTSTRAP_ROOMS)) {
 const app = express();
 app.use(cors());
 app.use(express.json({ limit: "1mb" }));
+app.use((req, res, next) => {
+  const requestIdHeader = req.header("x-request-id");
+  const requestId = requestIdHeader?.trim().length
+    ? requestIdHeader.trim()
+    : randomUUID();
+  const startedAt = Date.now();
+
+  runWithLogContext(
+    {
+      requestId,
+      method: req.method,
+      route: req.path,
+    },
+    () => {
+      logger.info("http.request.enter", {
+        hasBody: req.body !== undefined,
+      });
+      res.setHeader("x-request-id", requestId);
+      res.on("finish", () => {
+        logger.info("http.request.exit", {
+          statusCode: res.statusCode,
+          durationMs: Date.now() - startedAt,
+        });
+      });
+      res.on("close", () => {
+        if (!res.writableEnded) {
+          logger.debug("http.request.client_closed", {
+            durationMs: Date.now() - startedAt,
+          });
+        }
+      });
+      next();
+    },
+  );
+});
 
 app.get("/health", (_req, res) => {
   res.json({ ok: true });
@@ -188,65 +227,80 @@ app.use((error: unknown, _req: express.Request, res: express.Response, _next: ex
   const mapped = error instanceof z.ZodError
     ? invalidPayloadError({ issues: error.issues })
     : mapUnknownError(error);
+  logger.warn("http.request.error", {
+    statusCode: mapped.statusCode,
+    code: mapped.code,
+    error: serializeError(error),
+  });
   res.status(mapped.statusCode).json(mapped.toResponseBody());
 });
 
 app.listen(port, () => {
-  console.log(`[roomd] listening on http://localhost:${port}`);
+  logger.info("server.listen", { url: `http://localhost:${port}` });
   if (dangerouslyAllowStdio) {
-    console.warn(
-      "[roomd] WARNING: DANGEROUSLY_ALLOW_STDIO enabled (defaulting empty stdio allowlist to *).",
-    );
+    logger.warn("server.security_override_stdio", {
+      message:
+        "DANGEROUSLY_ALLOW_STDIO enabled; empty stdio allowlist defaults to wildcard.",
+    });
   }
   if (dangerouslyAllowRemoteHttp) {
-    console.warn(
-      "[roomd] WARNING: DANGEROUSLY_ALLOW_REMOTE_HTTP enabled (remote HTTP + origin wildcard allowed when unset).",
-    );
+    logger.warn("server.security_override_remote_http", {
+      message:
+        "DANGEROUSLY_ALLOW_REMOTE_HTTP enabled; remote HTTP and wildcard origins may be accepted.",
+    });
   }
   if (serverAllowlist.length > 0) {
-    console.log(`[roomd] server allowlist: ${serverAllowlist.join(", ")}`);
+    logger.info("server.allowlist", { serverAllowlist });
   }
   if (stdioCommandAllowlist.length > 0) {
-    console.log(
-      `[roomd] stdio command allowlist: ${stdioCommandAllowlist.join(", ")}`,
-    );
+    logger.info("server.stdio_allowlist", { stdioCommandAllowlist });
   }
   if (allowRemoteHttpServers) {
     const origins =
       remoteHttpOriginAllowlist.length > 0
         ? remoteHttpOriginAllowlist.join(", ")
         : "(none)";
-    console.log(`[roomd] remote HTTP enabled; origin allowlist: ${origins}`);
+    logger.info("server.remote_http_enabled", { origins });
   }
   if (Object.keys(httpAuthConfig).length > 0) {
-    console.log(
-      `[roomd] HTTP auth strategies configured for prefixes: ${Object.keys(httpAuthConfig).join(", ")}`,
-    );
+    logger.info("server.http_auth_configured", {
+      prefixes: Object.keys(httpAuthConfig),
+    });
   }
 });
 
 function parseCommaList(value: string | undefined): string[] {
+  logger.debug("parseCommaList.enter", { hasValue: !!value });
   if (!value) {
+    logger.debug("parseCommaList.exit", { items: 0 });
     return [];
   }
 
-  return value
+  const parsed = value
     .split(",")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+  logger.debug("parseCommaList.exit", { items: parsed.length });
+  return parsed;
 }
 
 function parseBoolean(value: string | undefined): boolean {
+  logger.debug("parseBoolean.enter", { hasValue: !!value });
   if (!value) {
+    logger.debug("parseBoolean.exit", { parsed: false });
     return false;
   }
-  return value.trim().toLowerCase() === "true";
+  const parsed = value.trim().toLowerCase() === "true";
+  logger.debug("parseBoolean.exit", { parsed });
+  return parsed;
 }
 
 function parseHttpAuthConfig(
   value: string | undefined,
 ): Record<string, HttpAuthStrategyConfig> {
+  logger.debug("parseHttpAuthConfig.enter", { hasValue: !!value });
   if (!value || value.trim().length === 0) {
+    logger.debug("parseHttpAuthConfig.exit", { prefixes: 0 });
     return {};
   }
 
@@ -270,29 +324,49 @@ function parseHttpAuthConfig(
     parsed = JSON.parse(value);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    logger.debug("parseHttpAuthConfig.json_error", {
+      error: serializeError(error),
+    });
     throw new Error(`ROOMD_HTTP_AUTH_CONFIG must be valid JSON: ${message}`);
   }
 
-  return authConfigSchema.parse(parsed);
+  const validated = authConfigSchema.parse(parsed);
+  logger.debug("parseHttpAuthConfig.exit", {
+    prefixes: Object.keys(validated).length,
+  });
+  return validated;
 }
 
 function parseSinceRevision(
   sinceRevisionQuery: unknown,
   lastEventIdHeader: string | undefined,
 ): number | undefined {
+  logger.debug("parseSinceRevision.enter", {
+    hasSinceRevisionQuery: typeof sinceRevisionQuery === "string",
+    hasLastEventIdHeader: !!lastEventIdHeader,
+  });
   if (typeof sinceRevisionQuery === "string" && sinceRevisionQuery.length > 0) {
-    return sinceRevisionSchema.parse(sinceRevisionQuery);
+    const parsed = sinceRevisionSchema.parse(sinceRevisionQuery);
+    logger.debug("parseSinceRevision.exit", { source: "query", parsed });
+    return parsed;
   }
 
   if (lastEventIdHeader && lastEventIdHeader.length > 0) {
-    return sinceRevisionSchema.parse(lastEventIdHeader);
+    const parsed = sinceRevisionSchema.parse(lastEventIdHeader);
+    logger.debug("parseSinceRevision.exit", { source: "last-event-id", parsed });
+    return parsed;
   }
 
+  logger.debug("parseSinceRevision.exit", { source: "none" });
   return undefined;
 }
 
 function writeSseEvent(res: express.Response, event: unknown): void {
   const eventObj = event as { type: string; revision: number };
+  logger.debug("writeSseEvent", {
+    type: eventObj.type,
+    revision: eventObj.revision,
+  });
   res.write(`id: ${eventObj.revision}\n`);
   res.write(`event: ${eventObj.type}\n`);
   res.write(`data: ${JSON.stringify(event)}\n\n`);

--- a/services/roomd/src/store.ts
+++ b/services/roomd/src/store.ts
@@ -16,6 +16,7 @@ import {
   parseToolsPage,
 } from "./store/parsing";
 import { assertServerAllowed as assertServerAllowedByPolicy } from "./store/server-policy";
+import { getRoomdLogger, serializeError } from "./logging";
 import type {
   ClientRoot,
   CompletionCompleteParams,
@@ -85,6 +86,7 @@ const INSPECTION_ROOM_ID = "__inspect__";
 export class RoomStore {
   private readonly rooms = new Map<string, RoomRuntime>();
   private invocationCounter = 1;
+  private readonly logger = getRoomdLogger({ component: "room_store" });
 
   private readonly eventWindowSize: number;
   private readonly invocationHistoryLimit: number;
@@ -203,6 +205,11 @@ export class RoomStore {
     roomId: string,
     envelope: CommandEnvelope,
   ): Promise<CommandExecutionResult> {
+    this.logger.info("applyCommand.enter", {
+      roomId,
+      commandType: envelope.command.type,
+      idempotencyKey: envelope.idempotencyKey,
+    });
     const room = this.requireRoom(roomId);
 
     const commandHash = stableStringify(envelope.command);
@@ -238,6 +245,12 @@ export class RoomStore {
       room.idempotency.delete(firstKey);
     }
 
+    this.logger.info("applyCommand.exit", {
+      roomId,
+      commandType: envelope.command.type,
+      statusCode: result.statusCode,
+      idempotencySize: room.idempotency.size,
+    });
     return result;
   }
 
@@ -262,13 +275,20 @@ export class RoomStore {
   }
 
   async inspectServer(serverUrl: string): Promise<ServerInspection> {
+    this.logger.info("inspectServer.enter", { serverUrl });
     const normalizedServer = normalizeServerTarget(serverUrl);
     this.assertServerAllowed(normalizedServer);
     try {
-      return await this.inspectServerWithSession(
+      const inspection = await this.inspectServerWithSession(
         INSPECTION_ROOM_ID,
         normalizedServer,
       );
+      this.logger.info("inspectServer.exit", {
+        serverUrl: normalizedServer,
+        tools: inspection.tools.length,
+        uiCandidates: inspection.uiCandidates.length,
+      });
+      return inspection;
     } finally {
       await this.sessionFactory.releaseSession(INSPECTION_ROOM_ID, normalizedServer);
     }
@@ -403,6 +423,12 @@ export class RoomStore {
     name: string,
     input: Record<string, unknown>,
   ): Promise<unknown> {
+    this.logger.info("callInstanceTool.enter", {
+      roomId,
+      instanceId,
+      toolName: name,
+      inputKeys: Object.keys(input),
+    });
     const room = this.requireRoom(roomId);
     const mount = this.requireMount(room, instanceId);
     ensureServerCapability(mount.session, "tools", "tools/call");
@@ -428,9 +454,9 @@ export class RoomStore {
       name,
       input,
     );
-
     this.insertInvocation(room, invocation);
-    room.selectedInstanceId = instanceId;
+    // GOTCHA: Tool calls can originate from background/hidden iframes; do not
+    // couple invocation traffic to UI selection, or selectedInstanceId will churn.
     this.appendEvidence(room, room.revision + 1, {
       source: "roomd",
       event: "rpc_sent",
@@ -461,6 +487,12 @@ export class RoomStore {
         });
         this.commit(currentRoom, "call-result");
       }
+      this.logger.info("callInstanceTool.exit", {
+        roomId,
+        instanceId,
+        toolName: name,
+        status: "completed",
+      });
       return result;
     } catch (error) {
       const currentRoom = this.requireRoom(roomId);
@@ -480,6 +512,12 @@ export class RoomStore {
         });
         this.commit(currentRoom, "call-failed");
       }
+      this.logger.debug("callInstanceTool.error", {
+        roomId,
+        instanceId,
+        toolName: name,
+        error: serializeError(error),
+      });
       throw error;
     }
   }
@@ -601,6 +639,7 @@ export class RoomStore {
     roomId: string,
     serverUrl: string,
   ): Promise<ServerInspection> {
+    this.logger.info("inspectServerWithSession.enter", { roomId, serverUrl });
     this.assertServerAllowed(serverUrl);
     const session = await this.getSession(roomId, serverUrl);
     const tools = await this.collectToolCatalog(session);
@@ -624,7 +663,7 @@ export class RoomStore {
     const autoMountable = uiCandidates.length === 1;
     const recommendedUiResourceUri = autoMountable ? uiCandidates[0] : undefined;
 
-    return {
+    const inspection = {
       server: serverUrl,
       tools,
       uiCandidates,
@@ -632,6 +671,14 @@ export class RoomStore {
       recommendedUiResourceUri,
       exampleCommands: buildExampleCommands(serverUrl, uiCandidates),
     };
+    this.logger.info("inspectServerWithSession.exit", {
+      roomId,
+      serverUrl,
+      tools: inspection.tools.length,
+      uiCandidates: inspection.uiCandidates.length,
+      autoMountable: inspection.autoMountable,
+    });
+    return inspection;
   }
 
   private async collectToolCatalog(session: McpSession): Promise<RoomMountTool[]> {
@@ -765,6 +812,11 @@ export class RoomStore {
     room: RoomRuntime,
     command: Extract<RoomCommand, { type: "mount" }>,
   ): Promise<CommandExecutionResult> {
+    this.logger.info("handleMount.enter", {
+      roomId: room.roomId,
+      instanceId: command.instanceId,
+      server: command.server,
+    });
     if (room.mounts.has(command.instanceId)) {
       throw new HttpError(
         409,
@@ -830,13 +882,25 @@ export class RoomStore {
         },
       });
       const state = this.commit(room, "mount");
-      return this.successWithState(state);
+      const response = this.successWithState(state);
+      this.logger.info("handleMount.exit", {
+        roomId: room.roomId,
+        instanceId: command.instanceId,
+        revision: state.revision,
+      });
+      return response;
     } catch (error) {
       if (!hadSessionForServer) {
         room.sessions.delete(normalizedServer);
         this.clientCapabilityRegistry.clear(room.roomId, normalizedServer);
         await this.sessionFactory.releaseSession(room.roomId, normalizedServer);
       }
+      this.logger.debug("handleMount.error", {
+        roomId: room.roomId,
+        instanceId: command.instanceId,
+        server: normalizedServer,
+        error: serializeError(error),
+      });
       throw error;
     }
   }
@@ -862,6 +926,7 @@ export class RoomStore {
     room: RoomRuntime,
     instanceId: string,
   ): Promise<CommandExecutionResult> {
+    this.logger.info("handleUnmount.enter", { roomId: room.roomId, instanceId });
     const mount = this.requireMount(room, instanceId);
     const mountedServer = mount.server;
 
@@ -894,7 +959,13 @@ export class RoomStore {
     );
 
     const state = this.commit(room, "unmount");
-    return this.successWithState(state);
+    const response = this.successWithState(state);
+    this.logger.info("handleUnmount.exit", {
+      roomId: room.roomId,
+      instanceId,
+      revision: state.revision,
+    });
+    return response;
   }
 
   private handleSelect(

--- a/services/roomd/tests/store.test.ts
+++ b/services/roomd/tests/store.test.ts
@@ -363,6 +363,7 @@ describe("RoomStore", () => {
         reasons.push(event.reason);
       }
     });
+    const selectedBeforeCall = store.getState("demo").selectedInstanceId;
 
     const result = await store.callInstanceTool("demo", "inst-1", "replace", {
       sessionId: "demo",
@@ -378,7 +379,7 @@ describe("RoomStore", () => {
     const invocation = state.invocations.at(-1);
     expect(invocation?.toolName).toBe("replace");
     expect(invocation?.status).toBe("completed");
-    expect(state.selectedInstanceId).toBe("inst-1");
+    expect(state.selectedInstanceId).toBe(selectedBeforeCall);
   });
 
   it("returns snapshot-reset when replay window is unavailable", async () => {


### PR DESCRIPTION
## Summary

This PR improves `roomd` observability, fixes a room state regression around tool execution, and tightens local dev startup so room-mode boot is more reliable.

## Why

`roomd` was still relying on scattered `console.*` output, which made request tracing and operational debugging noisy and inconsistent. At the same time, tool calls were mutating `selectedInstanceId`, which couples background invocation traffic to visible UI state and can cause selection churn. Local room-mode startup also had a race where reconnecting clients could hit `/rooms/:roomId/events` before the default room existed.

## What changed

### Structured logging across `roomd`
- Added a shared JSON logger with log levels, child loggers, async request context, and error serialization.
- Instrumented the HTTP server with request IDs, request enter/exit logs, request error logs, and SSE event logging.
- Added structured logs to instance routes, room-config routes, MCP session setup/teardown, MCP transport fallback/auth failures, room config operations, and key store workflows like mount/unmount, inspection, and tool calls.
- Replaced ad hoc `console.warn`/`console.info` logging in metadata parsing and room-config telemetry with the shared logger.

### Room state behavior fix
- Stopped `callInstanceTool` from overwriting `selectedInstanceId`.
- Added a GOTCHA comment documenting why tool invocation traffic must stay decoupled from UI selection.
- Updated the store test to lock this behavior.

### Local dev room bootstrap fix
- Added bootstrap-room resolution in the shared global config helper.
- Updated the `roomd` launcher to seed `ROOMD_BOOTSTRAP_ROOMS` from the configured host room when running in room mode, while preserving any explicit env-provided bootstrap rooms.
- Added a focused test for bootstrap-room resolution.
- Updated local runtime defaults in `config/global.yaml` for the current dev ports/server target.

### Docs and lockfile
- Simplified the top-level README command examples.
- Refreshed `package-lock.json` with dependency patch/minor updates from `npm install`.

## Behavior changes to review
- `roomd` logs now emit structured JSON rather than plain console strings.
- Room tool calls no longer implicitly select the instance that initiated the call.
- `npm run dev` in room mode should pre-create the configured room earlier in startup.

## Verification
- `node --test scripts/global-config.test.mjs`
- `npm run --workspace services/roomd test`

## Follow-ups / reviewer focus
- Confirm the new JSON logging shape is acceptable for downstream consumers.
- Confirm preserving `selectedInstanceId` during background tool calls matches intended host behavior.
- Confirm the updated local-dev ports in `config/global.yaml` are the intended defaults for the team.
