### PR TITLE
Fix roomctl config precedence and real-MCP lifecycle reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run roomd:cli -- room-config-save --room demo --config banking-room
 ```
 
 Global flags:
-- `--config` (default: `config/global.yaml` via upward lookup)
+- `--config` (highest priority, then `MCP_APP_ROOM_CONFIG`, then `config/global.yaml` via upward lookup)
 - `--base-url` (overrides `roomd.baseUrl` from config)
 - `--timeout` (default `10s`)
 - `--output pretty|json`

--- a/apps/host-web/asset-paths.ts
+++ b/apps/host-web/asset-paths.ts
@@ -1,0 +1,57 @@
+import { basename, join, resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+export interface HostAssetPaths {
+  distDir: string;
+  indexHtmlPath: string;
+  sandboxHtmlPath: string;
+}
+
+interface ResolveHostAssetPathsOptions {
+  moduleDir: string;
+  cwd?: string;
+  exists?: (path: string) => boolean;
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths));
+}
+
+function hasHostAssets(directory: string, exists: (path: string) => boolean): boolean {
+  return exists(join(directory, "index.html")) && exists(join(directory, "sandbox.html"));
+}
+
+export function resolveHostAssetPaths(
+  options: ResolveHostAssetPathsOptions,
+): HostAssetPaths {
+  const cwd = options.cwd ?? process.cwd();
+  const pathExists = options.exists ?? existsSync;
+  const moduleDir = options.moduleDir;
+
+  const candidateDirs = uniquePaths([
+    join(moduleDir, "dist"),
+    basename(moduleDir) === "dist" ? moduleDir : "",
+    resolve(moduleDir, "..", "dist"),
+    join(cwd, "dist"),
+    join(cwd, "apps", "host-web", "dist"),
+  ].filter((value) => value.length > 0));
+
+  for (const candidate of candidateDirs) {
+    if (!hasHostAssets(candidate, pathExists)) {
+      continue;
+    }
+    return {
+      distDir: candidate,
+      indexHtmlPath: join(candidate, "index.html"),
+      sandboxHtmlPath: join(candidate, "sandbox.html"),
+    };
+  }
+
+  throw new Error(
+    [
+      "Host web assets not found. Expected built index/sandbox HTML in one of:",
+      ...candidateDirs.map((path) => `- ${path}`),
+      "Run `npm run --workspace apps/host-web build` before starting the host.",
+    ].join("\n"),
+  );
+}

--- a/apps/host-web/package.json
+++ b/apps/host-web/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.1",
   "type": "module",
   "scripts": {
-    "build": "tsc --noEmit && concurrently \"cross-env INPUT=index.html vite build\" \"cross-env INPUT=sandbox.html vite build\"",
+    "build": "tsc --noEmit && cross-env INPUT=index.html vite build && cross-env INPUT=sandbox.html vite build --emptyOutDir false",
     "test": "cross-env INPUT=index.html vitest run",
-    "watch": "concurrently \"cross-env INPUT=index.html vite build --watch\" \"cross-env INPUT=sandbox.html vite build --watch\"",
+    "watch": "concurrently \"cross-env INPUT=index.html vite build --watch\" \"cross-env INPUT=sandbox.html vite build --watch --emptyOutDir false\"",
     "serve": "tsx --watch serve.ts",
     "start": "cross-env NODE_ENV=development npm run build && npm run serve",
     "dev": "cross-env NODE_ENV=development concurrently \"npm run watch\" \"npm run serve\""

--- a/apps/host-web/serve.ts
+++ b/apps/host-web/serve.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps";
 import { parse as parseYaml } from "yaml";
+import { resolveHostAssetPaths } from "./asset-paths";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -271,7 +272,8 @@ function loadRuntimeConfig(argv: string[]): RuntimeConfig {
   };
 }
 
-const DIRECTORY = join(__dirname, "dist");
+const hostAssetPaths = resolveHostAssetPaths({ moduleDir: __dirname });
+const DIRECTORY = hostAssetPaths.distDir;
 const runtimeConfig = loadRuntimeConfig(process.argv.slice(2));
 const HOST_PORT = runtimeConfig.hostPort;
 const SANDBOX_PORT = runtimeConfig.sandboxPort;
@@ -563,7 +565,25 @@ sandboxApp.get(["/", "/sandbox.html"], (req, res) => {
   res.setHeader("Pragma", "no-cache");
   res.setHeader("Expires", "0");
 
-  res.sendFile(join(DIRECTORY, "sandbox.html"));
+  // GOTCHA: the repo path can include hidden parent directories (e.g. ".codex").
+  // Passing an absolute path to sendFile can trigger send's dotfile guard and
+  // produce a 404 even when the target exists. Serve by filename + root instead.
+  res.sendFile("sandbox.html", {
+    root: hostAssetPaths.distDir,
+    dotfiles: "allow",
+  }, (error) => {
+    if (!error) {
+      return;
+    }
+    console.error(
+      "[Sandbox] Failed to serve sandbox HTML",
+      hostAssetPaths.sandboxHtmlPath,
+      error,
+    );
+    if (!res.headersSent) {
+      res.status(500).send("Failed to load sandbox runtime");
+    }
+  });
 });
 
 sandboxApp.use((_req, res) => {

--- a/apps/host-web/tests/asset-paths.test.ts
+++ b/apps/host-web/tests/asset-paths.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveHostAssetPaths } from "../asset-paths";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true })
+    ),
+  );
+});
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(directory);
+  return directory;
+}
+
+async function writeHostAssets(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, "index.html"), "<html>index</html>");
+  await writeFile(join(directory, "sandbox.html"), "<html>sandbox</html>");
+}
+
+describe("resolveHostAssetPaths", () => {
+  it("prefers moduleDir/dist when both host assets exist", async () => {
+    const moduleDir = await makeTempDir("host-assets-module-");
+    const moduleDist = join(moduleDir, "dist");
+    await writeHostAssets(moduleDist);
+
+    const resolved = resolveHostAssetPaths({ moduleDir, cwd: "/" });
+
+    expect(resolved.distDir).toBe(moduleDist);
+    expect(resolved.indexHtmlPath).toBe(join(moduleDist, "index.html"));
+    expect(resolved.sandboxHtmlPath).toBe(join(moduleDist, "sandbox.html"));
+  });
+
+  it("falls back to cwd/apps/host-web/dist when module candidates are missing", async () => {
+    const moduleDir = await makeTempDir("host-assets-empty-module-");
+    const cwd = await makeTempDir("host-assets-repo-root-");
+    const repoDist = join(cwd, "apps", "host-web", "dist");
+    await writeHostAssets(repoDist);
+
+    const resolved = resolveHostAssetPaths({ moduleDir, cwd });
+
+    expect(resolved.distDir).toBe(repoDist);
+  });
+
+  it("supports runtime where moduleDir is already dist", async () => {
+    const runtimeDir = await makeTempDir("host-assets-runtime-");
+    const moduleDist = join(runtimeDir, "dist");
+    await writeHostAssets(moduleDist);
+
+    const resolved = resolveHostAssetPaths({ moduleDir: moduleDist, cwd: "/" });
+
+    expect(resolved.distDir).toBe(moduleDist);
+  });
+
+  it("throws an actionable error when no candidate has both files", async () => {
+    const moduleDir = await makeTempDir("host-assets-missing-");
+
+    expect(() => resolveHostAssetPaths({ moduleDir, cwd: "/" })).toThrow(
+      "Run `npm run --workspace apps/host-web build` before starting the host.",
+    );
+  });
+});

--- a/docs/real-mcp-integration-testing.md
+++ b/docs/real-mcp-integration-testing.md
@@ -22,6 +22,9 @@ Run both real-MCP integration specs:
 npm run test:integration:real-mcp
 ```
 
+The script runs with `--workers=1` to avoid SQLite lock races between parallel
+roomd instances in shared test infrastructure.
+
 Included specs:
 
 - `e2e/playwright/roomctl-await-real-server.e2e.spec.ts`
@@ -30,6 +33,8 @@ Included specs:
 - `e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts`
   - Positive lifecycle path with real MCP server + roomd + host.
   - Asserts `bridge_connected` then `app_initialized`, and confirms default `tool-call` behavior.
+
+Both specs set `MCP_APP_ROOM_CONFIG` for roomctl calls (without passing explicit `--config`) to validate deterministic config resolution precedence in real workflows.
 
 ## Why negative path can fail without host
 
@@ -45,6 +50,7 @@ If host is not running for a test, missing `app_initialized` is expected and sho
    - Check `http://127.0.0.1:<port>/mcp` responds (status may be `406` without MCP payload, which is still a liveness signal).
 3. Host lifecycle evidence missing in positive spec:
    - Confirm host process started from the same generated global config as roomd.
+   - Confirm sandbox URL override points to configured sandbox port (the host default assumes `hostPort+1`).
    - Confirm room mount exists and UI tile is visible before awaiting lifecycle evidence.
 4. Security profile mismatches:
    - Integration specs expect `security.profile: local-dev` in generated config.

--- a/e2e/fixtures/integration-server/README.md
+++ b/e2e/fixtures/integration-server/README.md
@@ -12,7 +12,8 @@ Real MCP server fixture used by repository integration tests.
 
 - `main.mjs`: starts Streamable HTTP (`/mcp`) or stdio transport.
 - `server.mjs`: registers `get-time` tool and linked UI resource.
-- `dist/mcp-app.html`: bundled UI payload served as `text/html;profile=mcp-app`.
+- `mcp-app.html`: checked-in fallback UI payload served as `text/html;profile=mcp-app`.
+- `dist/mcp-app.html`: optional preferred build artifact when present.
 
 ## Run
 
@@ -29,4 +30,4 @@ This fixture is copied and adapted from:
 Adaptations are intentionally minimal:
 
 - JS runtime entrypoints (`.mjs`) so tests can launch with plain `node`.
-- Localized static UI bundle at `dist/mcp-app.html`.
+- Deterministic fixture UI payload with checked-in fallback (`mcp-app.html`).

--- a/e2e/fixtures/integration-server/mcp-app.html
+++ b/e2e/fixtures/integration-server/mcp-app.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Integration Fixture App</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+      }
+      .card {
+        background: #1e293b;
+        border: 1px solid #334155;
+        border-radius: 12px;
+        padding: 16px 20px;
+        max-width: 420px;
+      }
+      code {
+        color: #7dd3fc;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <strong>Integration Fixture App</strong>
+      <p>This fixture performs MCP App initialization and accepts tool notifications.</p>
+      <p>Last event: <code id="event">booting</code></p>
+    </div>
+    <script>
+      const PROTOCOL_VERSION = "2026-01-26";
+      const pending = new Map();
+      let nextId = 1;
+
+      function updateEvent(value) {
+        const target = document.getElementById("event");
+        if (target) target.textContent = value;
+      }
+
+      function send(message) {
+        window.parent.postMessage(message, "*");
+      }
+
+      function request(method, params) {
+        return new Promise((resolve, reject) => {
+          const id = nextId++;
+          pending.set(id, { resolve, reject });
+          send({ jsonrpc: "2.0", id, method, params });
+        });
+      }
+
+      window.addEventListener("message", (event) => {
+        const message = event.data;
+        if (!message || message.jsonrpc !== "2.0") return;
+
+        if (typeof message.id === "number" && (message.result !== undefined || message.error !== undefined)) {
+          const waiter = pending.get(message.id);
+          if (!waiter) return;
+          pending.delete(message.id);
+          if (message.error) {
+            waiter.reject(new Error(message.error.message || "JSON-RPC error"));
+          } else {
+            waiter.resolve(message.result);
+          }
+          return;
+        }
+
+        if (message.method === "ui/notifications/tool-input") {
+          updateEvent("tool-input");
+          return;
+        }
+        if (message.method === "ui/notifications/tool-result") {
+          updateEvent("tool-result");
+          return;
+        }
+        if (message.method === "ui/notifications/tool-cancelled") {
+          updateEvent("tool-cancelled");
+          return;
+        }
+        if (message.method === "ui/resource-teardown" && typeof message.id === "number") {
+          send({ jsonrpc: "2.0", id: message.id, result: {} });
+        }
+      });
+
+      async function initialize() {
+        await request("ui/initialize", {
+          appInfo: {
+            name: "Integration Fixture App",
+            version: "1.0.0",
+          },
+          appCapabilities: {},
+          protocolVersion: PROTOCOL_VERSION,
+        });
+        send({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+        updateEvent("initialized");
+      }
+
+      initialize().catch((error) => {
+        updateEvent("error");
+        console.error("[fixture-app] initialization failed", error);
+      });
+    </script>
+  </body>
+</html>

--- a/e2e/fixtures/integration-server/server.mjs
+++ b/e2e/fixtures/integration-server/server.mjs
@@ -12,7 +12,30 @@ import { z } from "zod";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DIST_DIR = path.join(__dirname, "dist");
+const FALLBACK_HTML_PATH = path.join(__dirname, "mcp-app.html");
 const RESOURCE_URI = "ui://get-time/mcp-app.html";
+
+async function loadFixtureHtml() {
+  const candidates = [
+    path.join(DIST_DIR, "mcp-app.html"),
+    FALLBACK_HTML_PATH,
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return await fs.readFile(candidate, "utf-8");
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(
+    `Fixture UI payload missing. Expected one of: ${candidates.join(", ")}`,
+  );
+}
 
 export function createServer() {
   const server = new McpServer({
@@ -52,7 +75,7 @@ export function createServer() {
     RESOURCE_URI,
     { mimeType: RESOURCE_MIME_TYPE },
     async () => {
-      const html = await fs.readFile(path.join(DIST_DIR, "mcp-app.html"), "utf-8");
+      const html = await loadFixtureHtml();
       return {
         contents: [{ uri: RESOURCE_URI, mimeType: RESOURCE_MIME_TYPE, text: html }],
       };

--- a/e2e/playwright/roomctl-await-real-server.e2e.spec.ts
+++ b/e2e/playwright/roomctl-await-real-server.e2e.spec.ts
@@ -210,8 +210,9 @@ test.describe("roomctl tool-call default await with local real server", () => {
 async function runRoomctl(configPath: string, args: string[]): Promise<Envelope> {
   const command = await runCommand(
     npmCmd,
-    ["run", "--silent", "roomd:cli", "--", "--config", configPath, ...args, "--output", "json"],
+    ["run", "--silent", "roomd:cli", "--", ...args, "--output", "json"],
     repoRoot,
+    { MCP_APP_ROOM_CONFIG: configPath },
   );
   if (command.exitCode !== 0) {
     throw new Error(`roomctl failed: ${command.stderr || command.stdout}`);
@@ -223,11 +224,15 @@ async function runCommand(
   command: string,
   args: string[],
   cwd: string,
+  env: NodeJS.ProcessEnv = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
-      env: process.env,
+      env: {
+        ...process.env,
+        ...env,
+      },
       stdio: "pipe",
     });
 

--- a/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
+++ b/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
@@ -30,6 +30,7 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
   let roomId = "";
   let roomdPort = 0;
   let hostPort = 0;
+  let sandboxPort = 0;
   let integrationPort = 0;
   let roomdBaseUrl = "";
   let integrationServerUrl = "";
@@ -42,7 +43,7 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
   test.beforeAll(async () => {
     roomdPort = await getFreePort();
     hostPort = await getFreePort();
-    const sandboxPort = await getFreePort();
+    sandboxPort = await getFreePort();
     integrationPort = await getFreePort();
 
     roomdBaseUrl = `http://127.0.0.1:${roomdPort}`;
@@ -161,7 +162,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
   test("host mount reaches app_initialized and default tool-call await succeeds", async ({
     page,
   }) => {
-    await page.goto(`http://127.0.0.1:${hostPort}/?theme=hide`);
+    // GOTCHA: Host defaults sandbox URL to hostPort+1; tests use arbitrary ports.
+    const sandboxUrl = `http://127.0.0.1:${sandboxPort}/sandbox.html`;
+    await page.goto(`http://127.0.0.1:${hostPort}/?theme=hide&sandbox=${encodeURIComponent(sandboxUrl)}`);
     await expect(page.locator('[data-instance-id="integration-1"]')).toBeVisible({
       timeout: 40_000,
     });
@@ -233,8 +236,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
 async function runRoomctl(configPath: string, args: string[]): Promise<Envelope> {
   const command = await runCommand(
     npmCmd,
-    ["run", "--silent", "roomd:cli", "--", "--config", configPath, ...args, "--output", "json"],
+    ["run", "--silent", "roomd:cli", "--", ...args, "--output", "json"],
     repoRoot,
+    { MCP_APP_ROOM_CONFIG: configPath },
   );
   if (command.exitCode !== 0) {
     throw new Error(`roomctl failed: ${command.stderr || command.stdout}`);
@@ -246,11 +250,15 @@ async function runCommand(
   command: string,
   args: string[],
   cwd: string,
+  env: NodeJS.ProcessEnv = {},
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
-      env: process.env,
+      env: {
+        ...process.env,
+        ...env,
+      },
       stdio: "pipe",
     });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:host": "npm run --workspace apps/host-web test",
     "test": "npm run test:roomd && npm run test:host",
     "test:go": "go test ./...",
-    "test:integration:real-mcp": "playwright test e2e/playwright/roomctl-await-real-server.e2e.spec.ts e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts --project=chromium",
+    "test:integration:real-mcp": "playwright test e2e/playwright/roomctl-await-real-server.e2e.spec.ts e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts --project=chromium --workers=1",
     "test:all": "npm run test && npm run test:go",
     "verify:fast": "npm run repo:guard && npm run arch:lint && npm run docs:check && npm run dev-sidebar:check-contracts",
     "verify": "npm run verify:fast && npm run build && npm run test:all",

--- a/tools/roomctl/README.md
+++ b/tools/roomctl/README.md
@@ -45,6 +45,7 @@ visible UI success.
 
 Config resolution:
 
-- `roomctl` reads `roomd.baseUrl` from `config/global.yaml` by default.
-- Override config path with `--config /path/to/global.yaml`.
+- `--config /path/to/global.yaml` (highest priority).
+- `MCP_APP_ROOM_CONFIG=/path/to/global.yaml` when `--config` is not provided.
+- Auto-discover `config/global.yaml` upward from current working directory when neither override is set.
 - Override URL directly with `--base-url http://host:port` (highest priority).

--- a/tools/roomctl/internal/roomctl/cli/integration_config_resolution_test.go
+++ b/tools/roomctl/internal/roomctl/cli/integration_config_resolution_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	roomctlconfig "github.com/duke/mcp-app-room/tools/roomctl/internal/roomctl/config"
+	"github.com/duke/mcp-app-room/tools/roomctl/internal/roomctl/roomd"
+)
+
+func TestConfigResolutionUsesEnvWhenFlagEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	configPath := writeGlobalConfigForTest(t, server.URL)
+	t.Setenv(roomctlconfig.ConfigPathEnvVar, configPath)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := newRootCmdWithOptions(&rootOptions{
+		timeout: 2 * time.Second,
+		output:  "json",
+		stdout:  stdout,
+		stderr:  stderr,
+	})
+	cmd.SetArgs([]string{"health"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute command failed: %v", err)
+	}
+
+	var env roomd.Envelope
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if env.Status != http.StatusOK {
+		t.Fatalf("status=%d want=%d", env.Status, http.StatusOK)
+	}
+}
+
+func TestConfigResolutionExplicitFlagWinsOverEnv(t *testing.T) {
+	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer goodServer.Close()
+
+	flagConfigPath := writeGlobalConfigForTest(t, goodServer.URL)
+	envConfigPath := writeGlobalConfigForTest(t, "http://127.0.0.1:1")
+	t.Setenv(roomctlconfig.ConfigPathEnvVar, envConfigPath)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := newRootCmdWithOptions(&rootOptions{
+		timeout: 2 * time.Second,
+		output:  "json",
+		stdout:  stdout,
+		stderr:  stderr,
+	})
+	cmd.SetArgs([]string{"--config", flagConfigPath, "health"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute command failed: %v", err)
+	}
+
+	var env roomd.Envelope
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if env.Status != http.StatusOK {
+		t.Fatalf("status=%d want=%d", env.Status, http.StatusOK)
+	}
+}
+
+func writeGlobalConfigForTest(t *testing.T, baseURL string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "global.yaml")
+	content := []byte("roomd:\n  baseUrl: \"" + baseURL + "\"\n")
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}

--- a/tools/roomctl/internal/roomctl/cli/root.go
+++ b/tools/roomctl/internal/roomctl/cli/root.go
@@ -88,7 +88,7 @@ func newRootCmdWithOptions(opts *rootOptions) *cobra.Command {
 	cmd.SetErr(opts.stderr)
 	cmd.SetOut(opts.stdout)
 
-	cmd.PersistentFlags().StringVar(&opts.configPath, "config", opts.configPath, "Path to global YAML config (default: auto-discover config/global.yaml)")
+	cmd.PersistentFlags().StringVar(&opts.configPath, "config", opts.configPath, "Path to global YAML config (highest priority; default resolution: MCP_APP_ROOM_CONFIG then auto-discover config/global.yaml)")
 	cmd.PersistentFlags().StringVar(&opts.baseURL, "base-url", opts.baseURL, "roomd base URL (overrides config)")
 	cmd.PersistentFlags().DurationVar(&opts.timeout, "timeout", opts.timeout, "HTTP timeout (e.g. 5s, 30s)")
 	cmd.PersistentFlags().StringVarP(&opts.output, "output", "o", opts.output, "Output format: pretty|json")
@@ -110,7 +110,7 @@ func newRootCmdWithOptions(opts *rootOptions) *cobra.Command {
 			baseURL = "<from config>"
 		}
 		if strings.TrimSpace(configPath) == "" {
-			configPath = "<auto-discover: config/global.yaml>"
+			configPath = "<auto-resolve: --config > MCP_APP_ROOM_CONFIG > config/global.yaml>"
 		}
 
 		fmt.Fprintln(out, "WHERE YOU ARE")
@@ -138,7 +138,7 @@ func newRootCmdWithOptions(opts *rootOptions) *cobra.Command {
 		fmt.Fprintln(out, "    - an MCP server is any implementation of the MCP spec that roomd can talk to over HTTP or stdio (e.g. an MCP-App or a custom server you built).")
 		fmt.Fprintln(out, "    - an MCP server provides tools, resources, and prompts that can be mounted into rooms as instances.")
 		fmt.Fprintln(out, "  - container: grid slot x,y,w,h (e.g. {{x}},{{y}},{{w}},{{h}})")
-		fmt.Println(out, "    - this is your 'view' of the UI that the user sees. if you don't know the size of viewport you're mounting to, or what else is mounted, you probably want to fetch it with inspect first.")
+		fmt.Fprintln(out, "    - this is your 'view' of the UI that the user sees. if you don't know the size of viewport you're mounting to, or what else is mounted, you probably want to fetch it with inspect first.")
 		fmt.Fprintln(out, "  - inspect: discover tools + UI candidates before mount")
 		fmt.Fprintln(out, "    - this is how you discover what an MCP server offers before you mount it. You can inspect at any time to see current tools/resources/prompts and available UI resource candidates.")
 		fmt.Fprintln(out, "    - a lot is required to know up front before you can mount, what tools there are, should you mount with a tool, should you ask the user before mounting and give them the options?")

--- a/tools/roomctl/internal/roomctl/config/config.go
+++ b/tools/roomctl/internal/roomctl/config/config.go
@@ -16,6 +16,8 @@ type GlobalConfig struct {
 	} `yaml:"roomd"`
 }
 
+const ConfigPathEnvVar = "MCP_APP_ROOM_CONFIG"
+
 func ResolveConfigPath(value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed != "" {
@@ -23,6 +25,14 @@ func ResolveConfigPath(value string) (string, error) {
 			return trimmed, nil
 		}
 		return filepath.Abs(trimmed)
+	}
+
+	envPath := strings.TrimSpace(os.Getenv(ConfigPathEnvVar))
+	if envPath != "" {
+		if filepath.IsAbs(envPath) {
+			return envPath, nil
+		}
+		return filepath.Abs(envPath)
 	}
 
 	cwd, err := os.Getwd()
@@ -44,7 +54,7 @@ func ResolveConfigPath(value string) (string, error) {
 		dir = parent
 	}
 
-	return "", errors.New("could not find config/global.yaml in current or parent directories")
+	return "", errors.New("could not resolve global config path; use --config, set MCP_APP_ROOM_CONFIG, or run from a directory containing config/global.yaml")
 }
 
 func Load(path string) (GlobalConfig, error) {

--- a/tools/roomctl/internal/roomctl/config/config_test.go
+++ b/tools/roomctl/internal/roomctl/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -41,5 +42,106 @@ func TestLoadFailsWhenBaseURLMissing(t *testing.T) {
 
 	if _, err := Load(configPath); err == nil {
 		t.Fatal("expected load to fail when roomd.baseUrl missing")
+	}
+}
+
+func TestResolveConfigPathExplicitWinsOverEnv(t *testing.T) {
+	dir := t.TempDir()
+	flagPath := filepath.Join(dir, "from-flag.yaml")
+	envPath := filepath.Join(dir, "from-env.yaml")
+	if err := os.WriteFile(flagPath, []byte("roomd:\n  baseUrl: http://localhost:8190\n"), 0o644); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("roomd:\n  baseUrl: http://localhost:8191\n"), 0o644); err != nil {
+		t.Fatalf("write env config: %v", err)
+	}
+
+	t.Setenv(ConfigPathEnvVar, envPath)
+	resolved, err := ResolveConfigPath(flagPath)
+	if err != nil {
+		t.Fatalf("resolve config path: %v", err)
+	}
+	if resolved != flagPath {
+		t.Fatalf("resolved=%q want=%q", resolved, flagPath)
+	}
+}
+
+func TestResolveConfigPathUsesEnvWhenFlagEmpty(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "from-env.yaml")
+	if err := os.WriteFile(envPath, []byte("roomd:\n  baseUrl: http://localhost:8191\n"), 0o644); err != nil {
+		t.Fatalf("write env config: %v", err)
+	}
+
+	t.Setenv(ConfigPathEnvVar, envPath)
+	resolved, err := ResolveConfigPath("")
+	if err != nil {
+		t.Fatalf("resolve config path: %v", err)
+	}
+	if resolved != envPath {
+		t.Fatalf("resolved=%q want=%q", resolved, envPath)
+	}
+}
+
+func TestResolveConfigPathAutoDiscoversFromCwdWhenFlagAndEnvEmpty(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "global.yaml")
+	if err := os.WriteFile(configPath, []byte("roomd:\n  baseUrl: http://localhost:8190\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	previousWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(previousWD)
+	})
+
+	t.Setenv(ConfigPathEnvVar, "")
+	resolved, err := ResolveConfigPath("")
+	if err != nil {
+		t.Fatalf("resolve config path: %v", err)
+	}
+	resolvedCanonical, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		t.Fatalf("canonicalize resolved path: %v", err)
+	}
+	expectedCanonical, err := filepath.EvalSymlinks(configPath)
+	if err != nil {
+		t.Fatalf("canonicalize expected path: %v", err)
+	}
+	if resolvedCanonical != expectedCanonical {
+		t.Fatalf("resolved=%q want=%q", resolvedCanonical, expectedCanonical)
+	}
+}
+
+func TestResolveConfigPathErrorIsActionable(t *testing.T) {
+	dir := t.TempDir()
+	previousWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir to temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(previousWD)
+	})
+
+	t.Setenv(ConfigPathEnvVar, "")
+	_, err = ResolveConfigPath("")
+	if err == nil {
+		t.Fatal("expected resolve config path to fail without flag/env/auto-discovered file")
+	}
+	if !strings.Contains(err.Error(), "--config") || !strings.Contains(err.Error(), ConfigPathEnvVar) {
+		t.Fatalf("expected actionable guidance in error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary\n- formalize roomctl config resolution precedence: explicit --config > MCP_APP_ROOM_CONFIG > auto-discovery\n- add CLI + config tests and update docs/help text to lock precedence behavior\n- harden host sandbox asset serving for hidden parent directories (e.g. .codex paths)\n- add deterministic integration fixture UI fallback and lifecycle e2e coverage improvements\n\n## Verification\n- npm run verify\n- npx playwright test e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts --project=chromium --workers=1\n\nFixes #31