### PR TITLE
Fix lifecycle await revision semantics + require real-MCP CI gate

### DIFF
--- a/.github/workflows/real-mcp-integration.yml
+++ b/.github/workflows/real-mcp-integration.yml
@@ -1,0 +1,44 @@
+name: real-mcp-integration
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  real-mcp-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run real MCP integration gate
+        run: npm run test:integration:real-mcp
+
+      - name: Upload real MCP artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-mcp-integration-artifacts
+          path: |
+            artifacts/real-mcp
+            test-results
+            playwright-report

--- a/e2e/playwright/roomctl-await-real-server.e2e.spec.ts
+++ b/e2e/playwright/roomctl-await-real-server.e2e.spec.ts
@@ -1,10 +1,15 @@
 import { expect, test } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { once } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import {
+  getFreePort,
+  pipeLogs,
+  runCommand,
+  terminateProcess,
+  waitForHttp,
+} from "./support/process-utils";
 
 type Envelope = {
   status: number;
@@ -218,109 +223,4 @@ async function runRoomctl(configPath: string, args: string[]): Promise<Envelope>
     throw new Error(`roomctl failed: ${command.stderr || command.stdout}`);
   }
   return JSON.parse(command.stdout) as Envelope;
-}
-
-async function runCommand(
-  command: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv = {},
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  return await new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env: {
-        ...process.env,
-        ...env,
-      },
-      stdio: "pipe",
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      resolve({
-        exitCode: code ?? 1,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-      });
-    });
-  });
-}
-
-function pipeLogs(prefix: string, child: ChildProcessWithoutNullStreams): void {
-  child.stdout.on("data", (chunk) => {
-    process.stdout.write(`${prefix} ${String(chunk)}`);
-  });
-  child.stderr.on("data", (chunk) => {
-    process.stderr.write(`${prefix} ${String(chunk)}`);
-  });
-}
-
-async function terminateProcess(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
-  if (!child || child.killed) {
-    return;
-  }
-
-  child.kill("SIGTERM");
-  const exitedOnTerm = await Promise.race([
-    once(child, "exit").then(() => true).catch(() => false),
-    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5_000)),
-  ]);
-  if (exitedOnTerm) {
-    return;
-  }
-
-  child.kill("SIGKILL");
-  await once(child, "exit").catch(() => undefined);
-}
-
-async function waitForHttp(
-  url: string,
-  isReady: (status: number) => boolean,
-  timeoutMs: number,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url);
-      if (isReady(response.status)) {
-        return;
-      }
-    } catch {
-      // retry until timeout
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(`Timed out waiting for ${url}`);
-}
-
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, "127.0.0.1");
-    server.on("listening", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("Unable to resolve free port"));
-        return;
-      }
-      const { port } = address;
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(port);
-      });
-    });
-    server.on("error", reject);
-  });
 }

--- a/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
+++ b/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
@@ -1,10 +1,15 @@
 import { expect, test } from "@playwright/test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { once } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import {
+  getFreePort,
+  pipeLogs,
+  runCommand,
+  terminateProcess,
+  waitForHttp,
+} from "./support/process-utils";
 
 type Envelope = {
   status: number;
@@ -20,6 +25,7 @@ const fixtureServerPath = path.join(
   "integration-server",
   "main.mjs",
 );
+const realMcpArtifactDir = path.join(repoRoot, "artifacts", "real-mcp");
 
 test.describe("roomctl lifecycle evidence with full real MCP fixture + host", () => {
   test.describe.configure({ mode: "serial" });
@@ -85,7 +91,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
       },
       stdio: "pipe",
     });
-    pipeLogs("[fixture-mcp]", integrationProcess);
+    pipeLogs("[fixture-mcp]", integrationProcess, {
+      logPath: path.join(realMcpArtifactDir, `${roomId}-fixture.log`),
+    });
     await waitForHttp(integrationServerUrl, (status) => status > 0, 20_000);
 
     roomdProcess = spawn(
@@ -100,7 +108,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
         stdio: "pipe",
       },
     );
-    pipeLogs("[roomd]", roomdProcess);
+    pipeLogs("[roomd]", roomdProcess, {
+      logPath: path.join(realMcpArtifactDir, `${roomId}-roomd.log`),
+    });
     await waitForHttp(`${roomdBaseUrl}/health`, (status) => status === 200, 30_000);
 
     const inspect = await runRoomctl(configPath, [
@@ -146,7 +156,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
         stdio: "pipe",
       },
     );
-    pipeLogs("[host]", hostProcess);
+    pipeLogs("[host]", hostProcess, {
+      logPath: path.join(realMcpArtifactDir, `${roomId}-host.log`),
+    });
     await waitForHttp(`http://127.0.0.1:${hostPort}/api/host-config`, (status) => status === 200, 45_000);
   });
 
@@ -186,6 +198,28 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
     expect(bridgeConnected.body.event).toBe("bridge_connected");
 
     const bridgeRevision = Number(bridgeConnected.body.revision ?? 0);
+    const resourceDelivered = await runRoomctl(configPath, [
+      "await",
+      "--room",
+      roomId,
+      "--instance",
+      "integration-1",
+      "--event",
+      "resource_delivered",
+      "--since-revision",
+      String(Math.max(0, bridgeRevision)),
+      "--max-wait",
+      "10s",
+      "--poll-interval",
+      "200ms",
+    ]);
+    // GOTCHA: `resource_delivered` is emitted best-effort in current host flow
+    // and can be skipped under lifecycle races even when bridge/app init is
+    // healthy. Track strict sequencing via dedicated follow-up.
+    expect([200, 408]).toContain(resourceDelivered.status);
+    const resourceRevision = Number(
+      resourceDelivered.status === 200 ? resourceDelivered.body.revision ?? 0 : bridgeRevision,
+    );
     const appInitialized = await runRoomctl(configPath, [
       "await",
       "--room",
@@ -195,7 +229,7 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
       "--event",
       "app_initialized",
       "--since-revision",
-      String(Math.max(0, bridgeRevision - 1)),
+      String(Math.max(0, resourceRevision)),
       "--max-wait",
       "90s",
       "--poll-interval",
@@ -203,6 +237,9 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
     ]);
     expect(appInitialized.status).toBe(200);
     expect(appInitialized.body.event).toBe("app_initialized");
+    const initializedRevision = Number(appInitialized.body.revision ?? 0);
+    expect(resourceRevision).toBeGreaterThanOrEqual(bridgeRevision);
+    expect(initializedRevision).toBeGreaterThanOrEqual(resourceRevision);
 
     const state = await runRoomctl(configPath, [
       "state",
@@ -244,109 +281,4 @@ async function runRoomctl(configPath: string, args: string[]): Promise<Envelope>
     throw new Error(`roomctl failed: ${command.stderr || command.stdout}`);
   }
   return JSON.parse(command.stdout) as Envelope;
-}
-
-async function runCommand(
-  command: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv = {},
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  return await new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd,
-      env: {
-        ...process.env,
-        ...env,
-      },
-      stdio: "pipe",
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      resolve({
-        exitCode: code ?? 1,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-      });
-    });
-  });
-}
-
-function pipeLogs(prefix: string, child: ChildProcessWithoutNullStreams): void {
-  child.stdout.on("data", (chunk) => {
-    process.stdout.write(`${prefix} ${String(chunk)}`);
-  });
-  child.stderr.on("data", (chunk) => {
-    process.stderr.write(`${prefix} ${String(chunk)}`);
-  });
-}
-
-async function terminateProcess(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
-  if (!child || child.killed) {
-    return;
-  }
-
-  child.kill("SIGTERM");
-  const exitedOnTerm = await Promise.race([
-    once(child, "exit").then(() => true).catch(() => false),
-    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5_000)),
-  ]);
-  if (exitedOnTerm) {
-    return;
-  }
-
-  child.kill("SIGKILL");
-  await once(child, "exit").catch(() => undefined);
-}
-
-async function waitForHttp(
-  url: string,
-  isReady: (status: number) => boolean,
-  timeoutMs: number,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url);
-      if (isReady(response.status)) {
-        return;
-      }
-    } catch {
-      // retry until timeout
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-  throw new Error(`Timed out waiting for ${url}`);
-}
-
-async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, "127.0.0.1");
-    server.on("listening", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("Unable to resolve free port"));
-        return;
-      }
-      const { port } = address;
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(port);
-      });
-    });
-    server.on("error", reject);
-  });
 }

--- a/e2e/playwright/support/process-utils.ts
+++ b/e2e/playwright/support/process-utils.ts
@@ -1,0 +1,139 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { createWriteStream, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { createServer } from "node:net";
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export async function runCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<CommandResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: "pipe",
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      resolve({
+        exitCode: code ?? 1,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      });
+    });
+  });
+}
+
+export function pipeLogs(
+  prefix: string,
+  child: ChildProcessWithoutNullStreams,
+  options?: { logPath?: string },
+): void {
+  const stream = options?.logPath
+    ? (() => {
+      mkdirSync(dirname(options.logPath), { recursive: true });
+      return createWriteStream(options.logPath, { flags: "a" });
+    })()
+    : undefined;
+
+  child.stdout.on("data", (chunk) => {
+    const line = `${prefix} ${String(chunk)}`;
+    process.stdout.write(line);
+    stream?.write(line);
+  });
+  child.stderr.on("data", (chunk) => {
+    const line = `${prefix} ${String(chunk)}`;
+    process.stderr.write(line);
+    stream?.write(line);
+  });
+
+  if (stream) {
+    child.on("close", () => {
+      stream.end();
+    });
+  }
+}
+
+export async function terminateProcess(
+  child: ChildProcessWithoutNullStreams | undefined,
+): Promise<void> {
+  if (!child || child.killed) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  const exitedOnTerm = await Promise.race([
+    once(child, "exit").then(() => true).catch(() => false),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ]);
+  if (exitedOnTerm) {
+    return;
+  }
+
+  child.kill("SIGKILL");
+  await once(child, "exit").catch(() => undefined);
+}
+
+export async function waitForHttp(
+  url: string,
+  isReady: (status: number) => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (isReady(response.status)) {
+        return;
+      }
+    } catch {
+      // retry until timeout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+export async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1");
+    server.on("listening", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to resolve free port"));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+    server.on("error", reject);
+  });
+}

--- a/tools/roomctl/internal/roomctl/cli/await.go
+++ b/tools/roomctl/internal/roomctl/cli/await.go
@@ -103,33 +103,33 @@ func awaitEvidence(
 	maxWait time.Duration,
 ) (bool, map[string]any, int, error) {
 	deadline := time.Now().Add(maxWait)
-	lastRevision := 0
+	lastStateRevision := 0
 	for {
 		stateEnv, err := client.State(ctx, roomID)
 		if err != nil {
-			return false, nil, lastRevision, err
+			return false, nil, lastStateRevision, err
 		}
 
-		matched, match, revision := findEvidenceMatch(
+		matched, match, matchedRevision, stateRevision := findEvidenceMatch(
 			stateEnv.Body,
 			eventName,
 			instanceID,
 			sinceRevision,
 		)
-		lastRevision = revision
+		lastStateRevision = stateRevision
 		if matched {
-			return true, match, revision, nil
+			return true, match, matchedRevision, nil
 		}
 
 		if time.Now().After(deadline) {
-			return false, nil, lastRevision, nil
+			return false, nil, lastStateRevision, nil
 		}
 
 		timer := time.NewTimer(pollInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return false, nil, lastRevision, ctx.Err()
+			return false, nil, lastStateRevision, ctx.Err()
 		case <-timer.C:
 		}
 	}
@@ -140,20 +140,20 @@ func findEvidenceMatch(
 	eventName string,
 	instanceID string,
 	sinceRevision int,
-) (bool, map[string]any, int) {
+) (bool, map[string]any, int, int) {
 	bodyMap, ok := body.(map[string]any)
 	if !ok {
-		return false, nil, 0
+		return false, nil, 0, 0
 	}
 	stateMap, ok := bodyMap["state"].(map[string]any)
 	if !ok {
-		return false, nil, 0
+		return false, nil, 0, 0
 	}
 
-	revision := asInt(stateMap["revision"])
+	stateRevision := asInt(stateMap["revision"])
 	evidenceList, ok := stateMap["evidence"].([]any)
 	if !ok {
-		return false, nil, revision
+		return false, nil, 0, stateRevision
 	}
 
 	wantInstance := strings.TrimSpace(instanceID)
@@ -171,10 +171,12 @@ func findEvidenceMatch(
 		if wantInstance != "" && strings.TrimSpace(asString(evidenceMap["instanceId"])) != wantInstance {
 			continue
 		}
-		return true, evidenceMap, revision
+		// GOTCHA: return the matched evidence revision, not the latest room
+		// state revision. Chained waits use this as a cursor.
+		return true, evidenceMap, asInt(evidenceMap["revision"]), stateRevision
 	}
 
-	return false, nil, revision
+	return false, nil, 0, stateRevision
 }
 
 func asString(value any) string {

--- a/tools/roomctl/internal/roomctl/cli/integration_await_test.go
+++ b/tools/roomctl/internal/roomctl/cli/integration_await_test.go
@@ -48,6 +48,9 @@ func TestAwaitCommandIntegrationMatchesEvidence(t *testing.T) {
 	if body["event"] != "app_initialized" {
 		t.Fatalf("event=%v want=app_initialized", body["event"])
 	}
+	if revision, ok := body["revision"].(float64); !ok || int(revision) != 7 {
+		t.Fatalf("revision=%v want=7 (matched evidence revision)", body["revision"])
+	}
 }
 
 func TestAwaitCommandIntegrationTimeout(t *testing.T) {
@@ -83,6 +86,44 @@ func TestAwaitCommandIntegrationTimeout(t *testing.T) {
 	}
 	if body["code"] != "EVIDENCE_TIMEOUT" {
 		t.Fatalf("code=%v want=EVIDENCE_TIMEOUT", body["code"])
+	}
+}
+
+func TestAwaitCommandIntegrationReturnsMatchedEvidenceRevisionWhenStateAdvances(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rooms/demo/state" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"ok":false}`))
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"state":{"revision":12,"evidence":[{"event":"resource_delivered","instanceId":"inst-1","revision":11}]}}`))
+	}))
+	defer server.Close()
+
+	env := runCommand(
+		t,
+		server.URL,
+		"await",
+		"--room", "demo",
+		"--instance", "inst-1",
+		"--event", "resource_delivered",
+		"--since-revision", "10",
+		"--poll-interval", "5ms",
+		"--max-wait", "100ms",
+	)
+
+	if env.Status != http.StatusOK {
+		t.Fatalf("status=%d want=%d", env.Status, http.StatusOK)
+	}
+	body, ok := env.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected body type: %T", env.Body)
+	}
+	if revision, ok := body["revision"].(float64); !ok || int(revision) != 11 {
+		t.Fatalf("revision=%v want=11 (matched evidence revision)", body["revision"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- refactored both real-MCP Playwright specs to use shared process helpers from `e2e/playwright/support/process-utils.ts`
- added host/roomd/fixture log persistence under `artifacts/real-mcp` for host-in-loop failures
- added required CI workflow `.github/workflows/real-mcp-integration.yml` to run `npm run test:integration:real-mcp` on PRs and main
- fixed `roomctl await` revision semantics to return the matched evidence revision (not latest room state revision)
- added regression coverage in `tools/roomctl/internal/roomctl/cli/integration_await_test.go` for advanced-state/matched-evidence races

## Root Cause
`roomctl await` surfaced `state.revision` in success responses. In chained waits, if the room revision had already advanced beyond the matched event (for example, resource-delivered matched at revision 11 while room state was revision 12), downstream waits incorrectly used 12 as the cursor and could miss the target event forever.

## Why this is permanent
- fixes the source behavior in `await.go` rather than relaxing assertions
- adds explicit regression tests for the exact revision race
- keeps host lifecycle assertions strict while tolerating known best-effort `resource_delivered` emission races

## Verification
- `npm run arch`
- `go test ./tools/roomctl/internal/roomctl/cli -run 'Await|ToolCall'`
- `npm run test:integration:real-mcp`
- `npm run verify`

Closes #27
