### PR TITLE
[V2 Debt] Strict-init lifecycle lock + pinned ext-apps baseline (#26)

### DIFF
--- a/apps/host-web/package.json
+++ b/apps/host-web/package.json
@@ -11,7 +11,7 @@
     "dev": "cross-env NODE_ENV=development concurrently \"npm run watch\" \"npm run serve\""
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "1.1.2",
     "@modelcontextprotocol/sdk": "^1.24.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains repository governance and architecture documentation.
 - `roomd-release-readiness-checklist.md`: release gate checklist tied to conformance evidence.
 - `real-mcp-integration-testing.md`: canonical real MCP integration fixture and test workflow.
 - `lifecycle-contract-source-of-truth.md`: canonical lifecycle contract and drift-check workflow.
+- `upstream-ext-apps-strict-init-reproducer.md`: upstream strict-init dependency tracking and blocker record.
 
 ## Update Workflow
 

--- a/docs/real-mcp-integration-testing.md
+++ b/docs/real-mcp-integration-testing.md
@@ -32,7 +32,7 @@ Included specs:
   - Host is intentionally not started, so `app_initialized` is expected to be missing.
 - `e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts`
   - Positive lifecycle path with real MCP server + roomd + host.
-  - Asserts `bridge_connected` then `app_initialized`, and confirms default `tool-call` behavior.
+  - Asserts `bridge_connected` then `app_initialized`, confirms default `tool-call` behavior, and rejects duplicate host `app_initialized` evidence for a mounted instance.
 
 Both specs set `MCP_APP_ROOM_CONFIG` for roomctl calls (without passing explicit `--config`) to validate deterministic config resolution precedence in real workflows.
 

--- a/docs/upstream-ext-apps-strict-init-reproducer.md
+++ b/docs/upstream-ext-apps-strict-init-reproducer.md
@@ -1,0 +1,53 @@
+# Upstream ext-apps Strict Init Reproducer
+
+## Scope
+
+This note tracks the strict-mode initialization idempotency dependency gap in
+`@modelcontextprotocol/ext-apps` and the local controls in `mcp-app-room`.
+
+## Upstream Status (as of 2026-03-08)
+
+- Upstream issue: [modelcontextprotocol/ext-apps#542](https://github.com/modelcontextprotocol/ext-apps/issues/542)
+- Upstream PR: [modelcontextprotocol/ext-apps#543](https://github.com/modelcontextprotocol/ext-apps/pull/543)
+- Upstream state: issue `OPEN`, PR `OPEN` (not merged, not released)
+
+## Local Reproducer Signals
+
+Canonical positive lifecycle suite:
+
+```bash
+npm run test:integration:real-mcp
+```
+
+Primary regression lock:
+
+- `e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts`
+  - requires `app_initialized` evidence for mounted host instance
+  - asserts no duplicate host `app_initialized` event for the same instance
+
+This prevents silent regressions where strict-mode transport sequencing accepts
+duplicate lifecycle progression.
+
+## Local Defense-In-Depth
+
+- Host room bootstrap keeps bridge wiring + evidence reporting isolated in
+  `apps/host-web/src/room-canvas/room-app-instance.tsx`.
+- Dependency is pinned to exact `@modelcontextprotocol/ext-apps@1.1.2` in
+  workspace manifests to prevent unreviewed semver drift while upstream fix is
+  unresolved.
+
+## Blocker Record
+
+- Owner: `team-platform` (this repository), `modelcontextprotocol/ext-apps` maintainers (upstream)
+- Blocked since: 2026-03-08
+- Earliest next check: 2026-03-15
+- Exit criteria:
+  1. Upstream PR merges.
+  2. Upstream package release contains fix.
+  3. This repo pins to released fixed version and reruns `npm run verify` and
+     `npm run test:integration:real-mcp`.
+
+## GOTCHA
+
+Do not relax the duplicate `app_initialized` assertion to make flaky runs pass.
+If this assertion fails, treat it as lifecycle truth regression and escalate.

--- a/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
+++ b/e2e/playwright/roomctl-real-server-host-lifecycle.e2e.spec.ts
@@ -247,6 +247,17 @@ test.describe("roomctl lifecycle evidence with full real MCP fixture + host", ()
       roomId,
     ]);
     expect(state.status).toBe(200);
+    const evidence = (state.body.state?.evidence ?? []) as Array<Record<string, any>>;
+    const hostInstanceEvidence = evidence.filter(
+      (item) => item.source === "host" && item.instanceId === "integration-1",
+    );
+    const appInitializedEvents = hostInstanceEvidence.filter(
+      (item) => item.event === "app_initialized",
+    );
+    // GOTCHA: Strict-mode bridge races have historically duplicated accepted
+    // initialize progression. Keep this lock strict to prevent regressions.
+    expect(appInitializedEvents).toHaveLength(1);
+
     const instances = (state.body.state?.assurance?.instances ?? []) as Array<Record<string, any>>;
     const assurance = instances.find((instance) => instance.instanceId === "integration-1");
     expect(assurance?.level).toBe("ui_app_initialized");

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "name": "@mcp-app-room/basic-host",
       "version": "1.0.1",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "1.1.2",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -6135,7 +6135,7 @@
       "name": "@mcp-app-room/roomd",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.0.0",
+        "@modelcontextprotocol/ext-apps": "1.1.2",
         "@modelcontextprotocol/sdk": "^1.24.0",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.6.2",

--- a/services/roomd/package.json
+++ b/services/roomd/package.json
@@ -14,7 +14,7 @@
     "conformance:check": "tsx src/conformance/check-threshold.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.0.0",
+    "@modelcontextprotocol/ext-apps": "1.1.2",
     "@modelcontextprotocol/sdk": "^1.24.0",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.6.2",


### PR DESCRIPTION
## Summary
- pins workspace `@modelcontextprotocol/ext-apps` dependency to exact `1.1.2` to prevent unreviewed semver drift while upstream strict-init fix is unresolved
- adds upstream-tracking repro + blocker documentation at `docs/upstream-ext-apps-strict-init-reproducer.md`
- strengthens canonical real-MCP lifecycle integration test to assert no duplicate host `app_initialized` evidence for a mounted instance
- updates docs index and real-MCP testing guide to reflect strict lifecycle regression lock

## Why
Issue #26 identified an upstream strict-mode init/idempotency dependency gap. Upstream references now exist and are active:
- https://github.com/modelcontextprotocol/ext-apps/issues/542
- https://github.com/modelcontextprotocol/ext-apps/pull/543

Until upstream merge + release happens, this repo still needs deterministic local protection:
- hard pin to known-good ext-apps version
- contract lock test that rejects duplicate lifecycle progression
- explicit blocker ownership + next check date

## Verification
- `npm run verify`
- `npm run test:integration:real-mcp`

## Blocker Status
- External blocker remains: upstream issue/PR open as of 2026-03-08.
- This PR lands all local actionable work and documents owner/date/next action.

Refs #26
