### PR TITLE
chore: automate strict-init upstream blocker checks

### DIFF
--- a/docs/upstream-ext-apps-strict-init-reproducer.md
+++ b/docs/upstream-ext-apps-strict-init-reproducer.md
@@ -12,6 +12,18 @@ This note tracks the strict-mode initialization idempotency dependency gap in
 - Upstream state: issue `OPEN`, PR `OPEN` (not merged)
 - Latest npm release observed: `@modelcontextprotocol/ext-apps@1.2.0` (published 2026-03-06)
 
+Automated status check command:
+
+```bash
+npm run upstream:strict-init:status
+```
+
+JSON output:
+
+```bash
+npm run upstream:strict-init:status -- --json
+```
+
 ## Local Reproducer Signals
 
 Canonical positive lifecycle suite:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "conformance:run": "npm run --workspace services/roomd conformance:run --",
     "conformance:check": "npm run --workspace services/roomd conformance:check --",
     "conformance:tier1": "npm run conformance:run && npm run conformance:check -- --threshold 1.0",
+    "upstream:strict-init:status": "node tools/upstream/check-ext-apps-strict-init.mjs",
     "docs:check": "node tools/docs/check-roomd-governance-docs.mjs",
     "dev-sidebar:check-contracts": "node tools/dev-sidebar/check-contract-drift.mjs",
     "arch:lint": "depcruise --config .dependency-cruiser.cjs --ignore-known .dependency-cruiser-known-violations.json apps services",

--- a/scripts/commands-help.mjs
+++ b/scripts/commands-help.mjs
@@ -33,6 +33,11 @@ const commands = [
     name: "npm run test:integration:real-mcp",
     description: "Run real MCP integration tests (negative + host lifecycle positive).",
   },
+  {
+    name: "npm run upstream:strict-init:status",
+    description:
+      "Check upstream strict-init blocker status (GitHub issue/PR + npm latest ext-apps).",
+  },
 ];
 
 console.log("Recommended commands");

--- a/tools/upstream/README.md
+++ b/tools/upstream/README.md
@@ -1,0 +1,16 @@
+# Upstream Blocker Utilities
+
+Small scripts for tracking external dependency blockers that gate local issue
+closure.
+
+## Strict Init Status Check
+
+```bash
+npm run upstream:strict-init:status
+```
+
+JSON output:
+
+```bash
+npm run upstream:strict-init:status -- --json
+```

--- a/tools/upstream/check-ext-apps-strict-init.mjs
+++ b/tools/upstream/check-ext-apps-strict-init.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Status probe for the strict-init upstream blocker.
+ *
+ * GOTCHA: This script uses unauthenticated GitHub REST calls and can hit
+ * rate limits if run aggressively in CI. Keep usage to periodic/manual checks.
+ */
+
+const strictInitIssueUrl =
+  "https://api.github.com/repos/modelcontextprotocol/ext-apps/issues/542";
+const strictInitPrUrl =
+  "https://api.github.com/repos/modelcontextprotocol/ext-apps/pulls/543";
+const npmRegistryUrl =
+  "https://registry.npmjs.org/%40modelcontextprotocol%2Fext-apps";
+
+const wantsJson = process.argv.includes("--json");
+
+async function main() {
+  const [issue, pullRequest, npmMetadata] = await Promise.all([
+    readJson(strictInitIssueUrl),
+    readJson(strictInitPrUrl),
+    readJson(npmRegistryUrl),
+  ]);
+
+  const latestVersion = npmMetadata?.["dist-tags"]?.latest ?? "unknown";
+  const latestPublishedAt =
+    npmMetadata?.time?.[latestVersion] ?? npmMetadata?.time?.modified ?? null;
+
+  const snapshot = {
+    checkedAt: new Date().toISOString(),
+    issue: {
+      number: issue.number,
+      state: issue.state,
+      updatedAt: issue.updated_at,
+      url: issue.html_url,
+    },
+    pullRequest: {
+      number: pullRequest.number,
+      state: pullRequest.state,
+      merged: Boolean(pullRequest.merged_at),
+      mergedAt: pullRequest.merged_at,
+      updatedAt: pullRequest.updated_at,
+      url: pullRequest.html_url,
+    },
+    npm: {
+      package: "@modelcontextprotocol/ext-apps",
+      latestVersion,
+      latestPublishedAt,
+    },
+  };
+
+  if (wantsJson) {
+    console.log(JSON.stringify(snapshot, null, 2));
+    return;
+  }
+
+  const lines = [
+    "ext-apps strict-init upstream status",
+    `checkedAt: ${snapshot.checkedAt}`,
+    `issue #${snapshot.issue.number}: ${snapshot.issue.state.toUpperCase()} (updated ${snapshot.issue.updatedAt})`,
+    `pull #${snapshot.pullRequest.number}: ${snapshot.pullRequest.state.toUpperCase()} merged=${snapshot.pullRequest.merged} (updated ${snapshot.pullRequest.updatedAt})`,
+    `npm latest: ${snapshot.npm.latestVersion} (published ${snapshot.npm.latestPublishedAt ?? "unknown"})`,
+    `issue url: ${snapshot.issue.url}`,
+    `pull url: ${snapshot.pullRequest.url}`,
+  ];
+  console.log(lines.join("\n"));
+}
+
+async function readJson(url) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "mcp-app-room/upstream-strict-init-check",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `request failed for ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.json();
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add `tools/upstream/check-ext-apps-strict-init.mjs` to fetch strict-init blocker state from upstream GitHub issue/PR and npm registry
- add `npm run upstream:strict-init:status` command and expose it in `npm run help`
- document the command in `docs/upstream-ext-apps-strict-init-reproducer.md` and `tools/upstream/README.md`

## Why
Issue #26 is in external-blocker watch mode. This removes manual drift in status checks and gives a deterministic command for every review cycle.

## Verification
- npm run upstream:strict-init:status
- npm run upstream:strict-init:status -- --json
- npm run verify:fast

## Ticket
- Refs #26
