### PR TITLE
docs: remove strict-init time-gated blocker wording

### DIFF
--- a/docs/upstream-ext-apps-strict-init-reproducer.md
+++ b/docs/upstream-ext-apps-strict-init-reproducer.md
@@ -66,7 +66,7 @@ Interpretation:
 
 - Owner: `team-platform` (this repository), `modelcontextprotocol/ext-apps` maintainers (upstream)
 - Blocked since: 2026-03-08
-- Earliest next check: 2026-03-15
+- Check cadence: every pickup/automation run (no date gate)
 - Exit criteria:
   1. Upstream PR merges.
   2. Upstream package release contains fix.


### PR DESCRIPTION
## Summary
- remove date-gated blocker wording from strict-init tracker doc
- align blocker record with continuous pickup-run checks (no time block)
- keep upstream closure condition strictly event-driven (merged + released)

## Verification
- npm run verify:fast

## Ticket
- Refs #26
